### PR TITLE
Planetary Space restriction breaks contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Added mod support to query the radiation model, as well as toggle visibility of belts and magnetopause (Sir Mortimer)
 * Added mod support for CME prediction accuracy that influences the probability that you get an advanced warning, and its accuracy (Sir Mortimer)
 * Configs for SoundingRockets (Arthur, Breach Candy)
+* Fixed DMOS experiment restriction to plantary space. This breaks some DMOS contracts that require experiments in solar orbit (Sir Mortimer)
 
 ## v3.0.2 for all versions of KSP from 1.4.0 to 1.7.x
 

--- a/GameData/KerbalismConfig/System/ScienceRework/ModSupport/DMagicOrbitalScience.cfg
+++ b/GameData/KerbalismConfig/System/ScienceRework/ModSupport/DMagicOrbitalScience.cfg
@@ -21,7 +21,7 @@
 			size = 8800
 			value = 9
 			duration = 2592000						// 120 days
-			requirements = PlanetarySpace
+			requirements = Microgravity
 			ResourceRates =
 			SetupMass = 0.015
 			SetupCost = 4500
@@ -34,7 +34,7 @@
 			size = 1100
 			value = 8
 			duration = 151200						// 7 days
-			requirements = PlanetarySpace,SunAngleMin:20,SunAngleMax:35
+			requirements = Microgravity,SunAngleMin:20,SunAngleMax:35
 			ResourceRates =
 			SetupMass = 0.03
 			SetupCost = 4000
@@ -47,7 +47,7 @@
 			size = 8425
 			value = 8
 			duration = 972000						// 45 days
-			requirements = PlanetarySpace
+			requirements = Microgravity
 			ResourceRates =
 			SetupMass = 0.02
 			SetupCost = 5000
@@ -60,7 +60,7 @@
 			size = 32584
 			value = 25
 			duration = 3024000						// 140 days
-			requirements = PlanetarySpace
+			requirements = Microgravity
 			ResourceRates =
 			SetupMass = 1
 			SetupCost = 7000
@@ -74,7 +74,7 @@
 			size = 45486
 			value = 40
 			duration = 3888000						// 180 days
-			requirements = PlanetarySpace
+			requirements = Microgravity
 			ResourceRates =
 			SetupMass = 1
 			SetupCost = 7500
@@ -140,7 +140,7 @@
 			size = 85274
 			value = 12
 			duration = 1944000						// 90 days
-			requirements = PlanetarySpace
+			requirements = Microgravity
 			ResourceRates =
 			SetupMass = 0.04
 			SetupCost = 4500
@@ -166,7 +166,7 @@
 			size = 7250
 			value = 12
 			duration = 453600						// 21 days
-			requirements = PlanetarySpace,SunAngleMin:5,SunAngleMax:60
+			requirements = Microgravity,SunAngleMin:5,SunAngleMax:60
 			ResourceRates =
 			SetupMass = 0.02
 			SetupCost = 4000
@@ -220,7 +220,7 @@
 			size = 365
 			value = 2								// nuked value due to biomes (changed the experiment, can't reproduce functionality)
 			duration = 302400						// 14 days PER BIOME. it'll take a while.
-			requirements = PlanetarySpace,OrbitMaxEccentricity:0.01,OrbitMinInclination:89.5,OrbitMaxInclination:90.5
+			requirements = Microgravity,OrbitMaxEccentricity:0.01,OrbitMinInclination:89.5,OrbitMaxInclination:90.5
 			ResourceRates =
 			SetupMass = 0.015
 			SetupCost = 12000

--- a/src/Kerbalism/Lib.cs
+++ b/src/Kerbalism/Lib.cs
@@ -860,7 +860,7 @@ namespace KERBALISM
 		public static double SunBodyAngle(Vessel v)
 		{
 			// orbit around sun?
-			if (v.mainBody.flightGlobalsIndex == 0) {
+			if (IsSun(v.mainBody)) {
 				return 0;
 			}
 
@@ -868,6 +868,11 @@ namespace KERBALISM
 			var body_sun = v.mainBody.position - FlightGlobals.Bodies[0].position;
 
 			return Vector3d.Angle(body_vessel, body_sun);
+		}
+
+		public static bool IsSun(CelestialBody body)
+		{
+			return body.flightGlobalsIndex == 0;
 		}
 
 		// --- VESSEL ---------------------------------------------------------------

--- a/src/Kerbalism/Science/Science.cs
+++ b/src/Kerbalism/Science/Science.cs
@@ -443,8 +443,8 @@ namespace KERBALISM
 					case "BodyWithAtmosphere": good = body.atmosphere; break;
 					case "BodyWithoutAtmosphere": good = !body.atmosphere; break;
 						
-					case "SunAngleMin": good = Lib.SunBodyAngle(v) >= double.Parse(value); break;
-					case "SunAngleMax": good = Lib.SunBodyAngle(v) <= double.Parse(value); break;
+					case "SunAngleMin": good = Lib.IsSun(v.mainBody) || Lib.SunBodyAngle(v) >= double.Parse(value); break;
+					case "SunAngleMax": good = Lib.IsSun(v.mainBody) || Lib.SunBodyAngle(v) <= double.Parse(value); break;
 
 					case "Vacuum": good = !body.atmosphere || v.altitude > body.atmosphereDepth; break;
 					case "Ocean": good = body.ocean && v.altitude < 0.0; break;


### PR DESCRIPTION
Imposing a planetary space restriction on DMOS experiemnts breaks some DMOS contracts that have you do surveys in solar orbit (which is defined as interplanetary).

Also, waive all sun angle restrictions while orbiting the sun.