### PR TITLE
Calculate shield rating with correct exponential function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Added mod support for CME prediction accuracy that influences the probability that you get an advanced warning, and its accuracy (Sir Mortimer)
 * Configs for SoundingRockets (Arthur, Breach Candy)
 * Fixed DMOS experiment restriction to plantary space. This breaks some DMOS contracts that require experiments in solar orbit (Sir Mortimer)
+* Improved shielding efficiency calculation (Free Thinker)
 
 ## v3.0.2 for all versions of KSP from 1.4.0 to 1.7.x
 

--- a/src/Kerbalism/Modules/Habitat.cs
+++ b/src/Kerbalism/Modules/Habitat.cs
@@ -463,11 +463,12 @@ namespace KERBALISM
 			return ResourceCache.Info(v, "MoistAtmosphere").level + 0.6;
 		}
 
-		// return shielding factor in a vessel
+		/// <summary>
+		/// Return vessel shielding factor.
+		/// </summary>
 		public static double Shielding(Vessel v)
 		{
-			// the shielding factor is simply the level of shielding, scaled by the 'shielding efficiency' setting
-			return ResourceCache.Info(v, "Shielding").level * PreferencesStorm.Instance.shieldingEfficiency;
+			return Radiation.ShieldingEfficiency(ResourceCache.Info(v, "Shielding").level);
 		}
 
 		// return living space factor in a vessel

--- a/src/Kerbalism/Radiation.cs
+++ b/src/Kerbalism/Radiation.cs
@@ -763,6 +763,21 @@ namespace KERBALISM
 			  : null;
 		}
 
+		/// <summary>
+		/// Calculate radiation shielding efficiency. Parameter shielding should be in range [0..1]
+		/// <para>
+		/// If you have a thickness which stops a known amount of radiation of a known and constant
+		/// type, then if you have a new thickness, you can calculate how much it stops by:
+		/// </para>
+		/// Stoppage = 1 - ((1 - AmountStoppedByKnownThickness)^(NewThickness / KnownThickness))
+		/// <para>
+		/// source : http://www.projectrho.com/public_html/rocket/radiation.php#id--Radiation_Shielding--Shielding--Shield_Rating
+		/// </para>
+		/// </summary>
+		public static double ShieldingEfficiency(double shielding)
+		{
+			return 1 - Math.Pow(1 - PreferencesStorm.Instance.shieldingEfficiency, Lib.Clamp(shielding, 0.0, 1.0));
+		}
 
 		static Dictionary<string, RadiationModel> models = new Dictionary<string, RadiationModel>(16);
 		static Dictionary<string, RadiationBody> bodies = new Dictionary<string, RadiationBody>(32);

--- a/src/Kerbalism/UI/Planner/VesselAnalyzer.cs
+++ b/src/Kerbalism/UI/Planner/VesselAnalyzer.cs
@@ -167,10 +167,10 @@ namespace KERBALISM.Planner
 			// calculate shielding factor
 			double amount = sim.Resource("Shielding").amount;
 			double capacity = sim.Resource("Shielding").capacity;
-			
-			shielding = capacity > double.Epsilon 
-                ? 1 - Math.Pow(1 - PreferencesStorm.Instance.shieldingEfficiency, amount / capacity) 
-                : PreferencesStorm.Instance.shieldingEfficiency;
+
+			shielding = capacity > double.Epsilon
+				? Radiation.ShieldingEfficiency(amount / capacity)
+				: PreferencesStorm.Instance.shieldingEfficiency;
 		}
 
 		void Analyze_reliability(List<Part> parts)

--- a/src/Kerbalism/UI/Planner/VesselAnalyzer.cs
+++ b/src/Kerbalism/UI/Planner/VesselAnalyzer.cs
@@ -167,7 +167,10 @@ namespace KERBALISM.Planner
 			// calculate shielding factor
 			double amount = sim.Resource("Shielding").amount;
 			double capacity = sim.Resource("Shielding").capacity;
-			shielding = (capacity > double.Epsilon ? amount / capacity : 1.0) * PreferencesStorm.Instance.shieldingEfficiency;
+			
+			shielding = capacity > double.Epsilon 
+                ? 1 - Math.Pow(1 - PreferencesStorm.Instance.shieldingEfficiency, amount / capacity) 
+                : PreferencesStorm.Instance.shieldingEfficiency;
 		}
 
 		void Analyze_reliability(List<Part> parts)


### PR DESCRIPTION
If you have a thickness which stops a known amount of radiation of a known and constant type, then if you have a new thickness, you can calculate how much it stops by:

Stoppage = 1 - ((1 - AmountStoppedByKnownThickness)^(NewThickness / KnownThickness))

source : http://www.projectrho.com/public_html/rocket/radiation.php#id--Radiation_Shielding--Shielding--Shield_Rating

new formula will give same result when configured with no shielding or max shielding, and in between it will improve the shield rating. This is absoluely required if you want to create any realistic shielding