### PR TITLE
Apply artificial radiation sources after Gamma Transparency is applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Configs for SoundingRockets (Arthur, Breach Candy)
 * Fixed DMOS experiment restriction to plantary space. This breaks some DMOS contracts that require experiments in solar orbit (Sir Mortimer)
 * Improved shielding efficiency calculation (Free Thinker)
-* Emmiters Radiation is applied after Gamma Transparency (Free Thinker)
+* Apply artificial radiation sources after Gamma Transparency is applied (Free Thinker)
 * Fixed the configuration for EVA kerbals, a problem introduced by Serenity (Sir Mortimer)
 
 ## v3.0.2 for all versions of KSP from 1.4.0 to 1.7.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Configs for SoundingRockets (Arthur, Breach Candy)
 * Fixed DMOS experiment restriction to plantary space. This breaks some DMOS contracts that require experiments in solar orbit (Sir Mortimer)
 * Improved shielding efficiency calculation (Free Thinker)
+* Emmiters Radiation is applied after Gamma Transparency (Free Thinker)
 * Fixed the configuration for EVA kerbals, a problem introduced by Serenity (Sir Mortimer)
 
 ## v3.0.2 for all versions of KSP from 1.4.0 to 1.7.x

--- a/src/Kerbalism/Radiation.cs
+++ b/src/Kerbalism/Radiation.cs
@@ -626,8 +626,7 @@ namespace KERBALISM
 			// add extern radiation
 			radiation += PreferencesStorm.Instance.ExternRadiation;
 
-			// add emitter radiation
-			radiation += Emitter.Total(v);
+
 
 			// if there is a storm in progress
 			if (Storm.InProgress(v))
@@ -637,13 +636,19 @@ namespace KERBALISM
 				if (magnetosphere) blackout = true;
 				else radiation += PreferencesStorm.Instance.StormRadiation * sunlight;
 			}
+			
+			// apply gamma transparency if inside atmosphere
+			radiation *= gamma_transparency
 
+			// add emitter radiation after atmosphere transparency
+			radiation += Emitter.Total(v);
+			
 			// clamp radiation to positive range
 			// note: we avoid radiation going to zero by using a small positive value
 			radiation = Math.Max(radiation, Nominal);
 
-			// return radiation, scaled by gamma transparency if inside atmosphere
-			return radiation * gamma_transparency;
+			// return radiation
+			return radiation;
 		}
 
 


### PR DESCRIPTION
Currently, any radiation emitters active in the atmosphere have virtually no effect on Radiation while being in a thick atmosphere. For engines like Nuclear Engines specialized for atmospheric usages, like Nuclear Ramjet, Nuclear Turbojet makes no sense the distance is usually very short and due to the effects of neutron scattering, the presence of an atmosphere would rather increase the radiation effect on crew then reduce it. 