### PR TITLE
MoistAtmosphere density fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Changes since the last release
 
-* Changed density of MoistAtmosphere to 0.00000485 inspired by sswelm aka. FreeThinker
-  Saturated water vapor at STP has a true density of 4.85 g/m3 at 273 K , which translates into a density of 0.00000485 which is 165.77 times less than currently!! (GordonDry)
+* Changed density of MoistAtmosphere to 0.00000485 (inspired by sswelm aka. FreeThinker) Saturated water vapor at STP has a true density of 4.85 g/m3 at 273 K , which translates into a density of 0.00000485 which is 165.77 times less than currently!! (GordonDry)
 * Support tilted magnetic fields and radiation belts with offsets (Sir Mortimer)
 * Updated the RSS radiation model according to http://evildrganymede.net/work/magfield.htm (Sir Mortimer)
 * Fixed an error in new science support for DMOS (Sir Mortimer)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changes since the last release
 
+* Changed density of MoistAtmosphere to 0.00000485 inspired by sswelm aka. FreeThinker
+  Saturated water vapor at STP has a true density of 4.85 g/m3 at 273 K , which translates into a density of 0.00000485 which is 165.77 times less than currently!! (GordonDry)
 * Support tilted magnetic fields and radiation belts with offsets (Sir Mortimer)
 * Updated the RSS radiation model according to http://evildrganymede.net/work/magfield.htm (Sir Mortimer)
 * Fixed an error in new science support for DMOS (Sir Mortimer)

--- a/GameData/KerbalismConfig/System/Resources.cfg
+++ b/GameData/KerbalismConfig/System/Resources.cfg
@@ -29,7 +29,7 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
   name = MoistAtmosphere 
-  density = 0.000804          // Saturated water vapor at STP , 100% humidity
+  density = 0.00000485          // Saturated water vapor at STP , 100% humidity
   unitCost = 0.0
   flowMode = ALL_VESSEL
   transfer = NONE


### PR DESCRIPTION
see https://github.com/Standecco/ROKerbalism/pull/10#issuecomment-509024275

> According to the resource file , MoistAtmosphere supposededly has a density of 0.000804. I notice that is very close to the density of Water which is 0.001. Saturated water vapor at STP has a true density of 4.85 g/m3 at 273 K , which translates into a density of 0.00000485 which is 165.77 times less than currently!!