### PR TITLE
KerbalAtomics: Added radiation source to nuclear engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Added config for Unkerballed start tech tree (Sir Mortimer)
 * Added config for a new ReStock+ probe core RC-XL001 (Sir Mortimer)
 * Radiation values in settings now take a preset from Settings.cfg (Sir Mortimer)
+* Added radiation source to kerbal atomics engines (Shiolle)
 
 ## v3.0.2 for all versions of KSP from 1.4.0 to 1.7.x
 

--- a/GameData/Kerbalism/Support/KerbalAtomics.cfg
+++ b/GameData/Kerbalism/Support/KerbalAtomics.cfg
@@ -38,3 +38,39 @@
 		radiation = 0.0000027777 // 0.01 rad/h
 	}
 }
+
+@PART[ntr-sc-0625-1]:NEEDS[FeatureRadiation] //NV-10 "Eel" Atomic Rocket Motor
+{
+	MODULE
+	{
+		name = Emitter
+		radiation = 0.0000005556 // 0.002 rad/h
+	}
+}
+
+@PART[ntr-sc-375-1]:NEEDS[FeatureRadiation] //NV-DC "Scylla" Atomic Aerospike Rocket
+{
+	MODULE
+	{
+		name = Emitter
+		radiation = 0.0000277778 // 0.1 rad/h
+	}
+}
+
+@PART[ntr-gc-25-2]:NEEDS[FeatureRadiation] //NV-GX "Emancipator" Atomic Rocket Motor
+{
+	MODULE
+	{
+		name = Emitter
+		radiation = 0.0000250000 // 0.09 rad/h
+	}
+}
+
+@PART[ntr-gc-25-3]:NEEDS[FeatureRadiation] //NV-GL "Deliverance" Atomic Aerospike Rocket
+{
+	MODULE
+	{
+		name = Emitter
+		radiation = 0.0000138889 // 0.05 rad/h
+	}
+}


### PR DESCRIPTION
Some of the nuclear thermal rockets in this mod are missing radiation sources. I've tried to add the missing values myself, extrapolating from existing engines according to their power.

See #469 