### PR TITLE
Fix for the stack overflow cache recursion loop -  #439

### DIFF
--- a/src/Kerbalism/Comms/AntennaInfoCommNet.cs
+++ b/src/Kerbalism/Comms/AntennaInfoCommNet.cs
@@ -181,6 +181,10 @@ namespace KERBALISM
 			return transmitters;
 		}
 
+
+		private static string lastTestedId;
+
+
 		protected virtual void Init()
 		{
 			if(!antennaInfo.powered || v.connection == null)
@@ -209,8 +213,21 @@ namespace KERBALISM
 				if (antennaInfo.status != (int)LinkStatus.direct_link)
 				{
 					Vessel firstHop = Lib.CommNodeToVessel(v.Connection.ControlPath.First.end);
-					// Get rate from the firstHop, each Hop will do the same logic, then we will have the min rate for whole path
-					antennaInfo.rate = Math.Min(Cache.VesselInfo(FlightGlobals.FindVessel(firstHop.id)).connection.rate, antennaInfo.rate);
+					string thisTestedId = FlightGlobals.FindVessel(firstHop.id).ToString();
+
+					// Prevent the recursion loop
+					if (lastTestedId == thisTestedId)
+					{
+						antennaInfo.rate = 0;
+					}
+					else
+					{ 
+						lastTestedId = thisTestedId;
+						// Get rate from the firstHop, each Hop will do the same logic, then we will have the min rate for whole path
+						antennaInfo.rate = Math.Min(Cache.VesselInfo(FlightGlobals.FindVessel(firstHop.id)).connection.rate, antennaInfo.rate);
+
+					}
+					
 				}
 			}
 			// is loss of connection due to plasma blackout


### PR DESCRIPTION
Small change, its a hack fix - does not address the underlying condition causing recursion, just basically saves the last vessel id and if it sees that it's calling function for same id then it doesn't go to cache.  Else proceed normally. 

 #439 was killing me, causing ctd , sometimes without logging the error. Have not had problem since.  Might cause some hinkyness in transmission of science, but not sure of that.
