### PR TITLE
improved engine rated ignitions formula

### DIFF
--- a/GameData/KerbalismConfig/System/Reliability.cfg
+++ b/GameData/KerbalismConfig/System/Reliability.cfg
@@ -478,19 +478,82 @@
 	}
 }
 
-// this calculates ignitions from thrust. the lower the thrust, the higher the ignition count.
-// thrust 0-200 gives 165-1 ignitions (linear scale). this will be multiplied for some types below
-// everything above that are heavy lifters for first stages
-@PART[*]:HAS[@MODULE[ModuleEnginesFX]:HAS[#maxThrust[<220]]]:NEEDS[FeatureReliability]:FOR[Kerbalism]
+// this calculates ignitions from thrust, and vac/atm ISP ratio:
+// - the lower the thrust, the higher the ignition count.
+// - the higher the difference between vacuum and atmosphere ISP, the higher the ignition count.
+// thrust 0-350 gives 64-1 ignitions (custom exponential-ish scale).
+// vac/atm ratio gives no bonus if below 150%, and then a linear bonus of +1 ignitions for every extra 20%.
+// some specific engine types will receive further bonus.
+@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[#maxThrust,@atmosphereCurve]]:NEEDS[FeatureReliability]:FOR[Kerbalism]
 {
 	@MODULE[Reliability]
 	{
-		@rated_ignitions = #$../MODULE[ModuleEngines*]/maxThrust$
-		@rated_ignitions /= -220
-		@rated_ignitions += 1 // it's now a number between 0 and 1
-		@rated_ignitions *= 165
-		@rated_ignitions ^= :\.\d+:: // truncate at decimal point
-		@rated_ignitions += 1 // just to make sure it's not 0
+		// Parse and store atmosphere ISP as a temporary value
+		__tmp_isp_atm = #$../MODULE[ModuleEngines*]/atmosphereCurve/key,1$
+		@__tmp_isp_atm ^= :^. (\d+) *.*$:$1:
+
+		// Parse and store vacuum ISP as a temporary value
+		__tmp_isp_vac = #$../MODULE[ModuleEngines*]/atmosphereCurve/key,0$
+		@__tmp_isp_vac ^= :^. (\d+) *.*$:$1:
+
+		// Give ignitions based on the ratio between vacum and atmosphere ISP
+		// ----
+		// Example results for typical stock engines:
+		// Spider => 1
+		// Ant => 13
+		// Twitch => 1
+		// Terrier => 13
+		// Thud => 1
+		// LV-T30 => 1
+		// Poodle => 12
+		// Mainsail => 1
+		@rated_ignitions = #$__tmp_isp_vac$
+		@rated_ignitions /= #$__tmp_isp_atm$ // Get the ratio between vacum and atmosphere ISP
+		@rated_ignitions -= 1.5 // Zero the curve to a ratio of 1.5
+		@rated_ignitions ^= :^-.*$:0: // If negative, set to zero
+		@rated_ignitions *= 5 // Give a power of 5 to the curve
+		@rated_ignitions += 1 // Set a minimum value of 1
+
+		// Give extra ignitions the smaller the engine is
+		// ----
+		// Example results for typical stock engines:
+		// Spider => +64
+		// Ant => +64
+		// Twitch => +32
+		// Terrier => +10
+		// Thud => +8
+		// LV-T30 => +4
+		// Poodle => +2
+		// Mainsail => +0
+		__tmp_thrust_factor = #$../MODULE[ModuleEngines*]/maxThrust$
+		@__tmp_thrust_factor ^= :^[0-9]$:_64: // if thrust between 0 and 9, give +64 ignitions
+		@__tmp_thrust_factor ^= :^1[0-9]$:_32: // if thrust between 10 and 19, give +32 ignitions
+		@__tmp_thrust_factor ^= :^[2-4][0-9]$:_16: // if thrust between 20 and 49, give +16 ignitions
+		@__tmp_thrust_factor ^= :^[5-9][0-9]$:_10: // if thrust between 50 and 99, give +10 ignitions
+		@__tmp_thrust_factor ^= :^1[0-4][0-9]$:_8: // if thrust between 100 and 149, give +8 ignitions
+		@__tmp_thrust_factor ^= :^1[5-9][0-9]$:_6: // if thrust between 150 and 199, give +6 ignitions
+		@__tmp_thrust_factor ^= :^2[0-4][0-9]$:_4: // if thrust between 200 and 249, give +4 ignitions
+		@__tmp_thrust_factor ^= :^2[5-9][0-9]$:_2: // if thrust between 250 and 299, give +2 ignitions
+		@__tmp_thrust_factor ^= :^3[0-9][0-9]$:_1: // if thrust between 300 and 349, give +1 ignitions
+		@__tmp_thrust_factor ^= :^[^_].*$:_0: // if thrust is 350 or more, give +0 ignitions
+		@__tmp_thrust_factor ^= :_:: // remove the "_" prefix
+
+		// Combine the two ignitions values
+		// ----
+		// Final sum for the previous examples:
+		// Spider => 65
+		// Ant => 77
+		// Twitch => 33
+		// Terrier => 23
+		// Thud => 9
+		// LV-T30 => 5
+		// Poodle => 14
+		// Mainsail => 1
+		@rated_ignitions += #$__tmp_thrust_factor$
+		@rated_ignitions ^= :\.\d+:: // Floor value to get an integer
+
+		// Remove all temporary variables
+		!__tmp_* = dummy
 	}
 }
 
@@ -533,7 +596,6 @@
 		@rated_operation_duration = 0
 		@turnon_failure_probability = 0.002
 		@repair = Engineer@2
-		@rated_ignitions *= 4
 	}
 }
 


### PR DESCRIPTION
Engine rated ignitions are now calculated using a formula that better suits gameplay and common sense:
- the lower the thrust, the higher the ignition count (exponential-ish scale).
- the higher the difference between vacuum and atmosphere ISP, the higher the ignition count.

Meaning that tiny engines always get many ignitions, and the biggest engines get very few, unless they are designed for vacuum use (very low atmosphere ISP compared to vacuum ISP).

See code comments for more details and examples.