### PR TITLE
Reversed slot upgrades in SSPXr inflatable habitats

### DIFF
--- a/GameData/KerbalismConfig/Support/SSPX.cfg
+++ b/GameData/KerbalismConfig/Support/SSPX.cfg
@@ -88,7 +88,7 @@
 	{
 		name = Configure
 		title = Pod
-		slots = 2
+		slots = 0
 
 		UPGRADES
 		{
@@ -96,7 +96,7 @@
 			{
 				name__ = Upgrade-Slots
 				techRequired__ = electronics
-				slots = 0
+				slots = 2
 			}
 		}
 
@@ -266,7 +266,7 @@
 	{
 		name = Configure
 		title = Pod
-		slots = 2
+		slots = 0
 
 		UPGRADES
 		{
@@ -274,7 +274,7 @@
 			{
 				name__ = Upgrade-Slots
 				techRequired__ = electronics
-				slots = 0
+				slots = 2
 			}
 		}
 


### PR DESCRIPTION
The inflatable habs start out with 2 life support slots which get "upgraded" down to 0. This patch reverses the numbers. ( #520 )