### PR TITLE
Lib.HumanReadableDuration displays large values as negative (the haunting of 32bit)

### DIFF
--- a/src/Kerbalism/Lib.cs
+++ b/src/Kerbalism/Lib.cs
@@ -763,16 +763,16 @@ namespace KERBALISM
 				if (d <= double.Epsilon) return "none";
 				if (double.IsInfinity(d) || double.IsNaN(d)) return "perpetual";
 
-				int hours_in_day = (int)HoursInDay;
-				int days_in_year = (int)DaysInYear;
+				long hours_in_day = (long)HoursInDay;
+				long days_in_year = (long)DaysInYear;
 
-				int duration_seconds = (int)d;
+				long duration_seconds = (long)d;
 
-				int seconds = duration_seconds % 60;
-				int minutes = (duration_seconds / 60) % 60;
-				int hours = (duration_seconds / 3600) % hours_in_day;
-				int days = (duration_seconds / (3600 * hours_in_day)) % days_in_year;
-				int years = duration_seconds / (3600 * hours_in_day * days_in_year);
+				long seconds = duration_seconds % 60;
+				long minutes = (duration_seconds / 60) % 60;
+				long hours = (duration_seconds / 3600) % hours_in_day;
+				long days = (duration_seconds / (3600 * hours_in_day)) % days_in_year;
+				long years = duration_seconds / (3600 * hours_in_day * days_in_year);
 
 
 				// seconds
@@ -798,15 +798,15 @@ namespace KERBALISM
 				double hours_in_day = HoursInDay;
 				double days_in_year = DaysInYear;
 
-				int duration = (int)d;
-				int seconds = duration % 60;
+				long duration = (long)d;
+				long seconds = duration % 60;
 				duration /= 60;
-				int minutes = duration % 60;
+				long minutes = duration % 60;
 				duration /= 60;
-				int hours = duration % (int)hours_in_day;
-				duration /= (int)hours_in_day;
-				int days = duration % (int)days_in_year;
-				int years = duration / (int)days_in_year;
+				long hours = duration % (long)hours_in_day;
+				duration /= (long)hours_in_day;
+				long days = duration % (long)days_in_year;
+				long years = duration / (long)days_in_year;
 
 				string result = string.Empty;
 				if (years > 0) result += years + "y ";


### PR DESCRIPTION
The code to format durations casts a double value to a 32bit integer. With just a moderate amount of resources, this can lead to negative values:
![negative duration](https://user-images.githubusercontent.com/758097/68543719-518a3080-03bb-11ea-9d06-d7b852214575.png)

As a minimum, the type of duration_seconds needs changing, other variables could stay 32bit. This patch converts int to long, which should fix the issue for most crafts (a 64bit long is still not large enough to hold the maxium value of a double). 

A "proper" solution would probably use Convert.ToInt64 and handle any overflow exceptions or go even bigger - but I'm not sure how that would affect performance for everyone not planning multi-aeon missions or trying to inflate a portable moon.

Other uses of int in Lib appear to be fine. There are some theoretical overflows but probably nothing that should ever happen in normal flight. I can add another request with individual patchs for two or three marginal improvements.