### PR TITLE
Bluedog_DB support add IDCSP

### DIFF
--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -226,7 +226,7 @@
 {
 	@RESOURCE[ElectricCharge]
 	{
-		@amount = 20 // old value 5, enough for about 5 minutes, so now about 20 minutes
-		@maxAmount = 20
+		@amount = 12 // old value 5, enough for about 8 minutes, so now about 20 minutes
+		@maxAmount = 12
 	}
 }

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -209,10 +209,24 @@
 // Increase xmitDataScalar on Bluedog DB early probes
 // by Gordon Dry
 // ============================================================================
-@PART[bluedog_Explorer1,bluedog_Pioneer1,bluedog_Pioneer4,bluedog_Vanguard,bluedog_Sputnik3_Core]:HAS[@MODULE[*ModuleScience*]]:NEEDS[FeatureScience]:FOR[zzzKerbalismDefault]
+@PART[bluedog_Explorer1,bluedog_Pioneer1,bluedog_Pioneer4,bluedog_Vanguard,bluedog_Sputnik3_Core]:HAS[@MODULE[*ModuleScience*]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
 {
 	@MODULE[*ModuleScience*],*:HAS[#experimentID[bd_GeigerCounter]]      { @xmitDataScalar = 1 } 
 	@MODULE[*ModuleScience*],*:HAS[#experimentID[temperatureScan]]       { @xmitDataScalar = 1 } 
 	@MODULE[*ModuleScience*],*:HAS[#experimentID[bd_magScan]]            { @xmitDataScalar = 1 } 
 	@MODULE[*ModuleScience*],*:HAS[#experimentID[logIonTrap]]            { @xmitDataScalar = 1 } 
+}
+
+// ============================================================================
+// Give early IDCSP relay more EC to survive more than 5 minutes in the dark
+// but not too much, and do not increase the solar panel output
+// by Gordon Dry
+// ============================================================================
+@PART[bluedog_IDCSP_Probe]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@RESOURCE[ElectricCharge]
+	{
+		@amount = 20 // old value 5, enough for about 5 minutes, so now about 20 minutes
+		@maxAmount = 20
+	}
 }


### PR DESCRIPTION
Give early IDCSP relay more EC to survive more than 5 minutes in the dark, but not too much, and do not increase the solar panel output.