### PR TITLE
XenonGas tank pressure

### DIFF
--- a/GameData/KerbalismConfig/Profiles/Default.cfg
+++ b/GameData/KerbalismConfig/Profiles/Default.cfg
@@ -1095,15 +1095,16 @@ PARTUPGRADE:NEEDS[ProfileDefault]
 
     SETUP
     {
-      name = Xenon Gas  // Stored at 180 bar (2646psi) when full
-      desc = Store pressurized <b>Xenon</b> gas @ 180 bar.
+      name = Xenon Gas  // Stored at 85 bar (1250psi) when full
+						// see https://www.cobham.com/mission-systems/composite-pressure-solutions/space-systems/xenon-propellant-tank-datasheet/
+      desc = Store pressurized <b>Xenon</b> gas @ 85 bar.
       tech = ionPropulsion
 
       RESOURCE
       {
         name = XenonGas
-        amount = 12
-        maxAmount = 12
+        amount = 85
+        maxAmount = 85
         @amount *= #$/ContainerVolume$
         @maxAmount *= #$/ContainerVolume$
       }

--- a/GameData/KerbalismConfig/Support/B9PartSwitch.cfg
+++ b/GameData/KerbalismConfig/Support/B9PartSwitch.cfg
@@ -166,7 +166,8 @@ B9_TANK_TYPE
 	RESOURCE
 	{
 		name = XenonGas
-		unitsPerVolume = 12
+		unitsPerVolume = 85
+		// see https://www.cobham.com/mission-systems/composite-pressure-solutions/space-systems/xenon-propellant-tank-datasheet/
 	}
 }
 


### PR DESCRIPTION
After I found a discrepancy between GameData\KerbalismConfig\Profiles\Default.cfg
saying
```
        SETUP
        {
            name = Xenon Gas    // Stored at 180 bar (2646psi) when full
            desc = Store pressurized <b>Xenon</b> gas @ 180 bar.
            tech = ionPropulsion

            RESOURCE
            {
                name = XenonGas
                amount = 180
                maxAmount = 180
                @amount *= #$/ContainerVolume$
                @maxAmount *= #$/ContainerVolume$
            }
        }
```
and GameData\KerbalismConfig\Support\B9PartSwitch.cfg
saying
```
B9_TANK_TYPE
{
    name = XenonGas
    tankMass =  0.00010627500
    tankCost = 0.25

    RESOURCE
    {
        name = XenonGas
        unitsPerVolume = 12
    }
}
```
and some Discord chatting @SirMortimer committed https://github.com/Kerbalism/Kerbalism/commit/fea96175f33a5985fc97561a9dcb532b0be737d2

Meanwhile I found these infos:
http://emits.sso.esa.int/emits-doc/ASTRIUMLIM/BepiColombo_MTM_Xenon_Storage_Tank/BC.ASU.SP.00009.XeStTank.Req.Spec.pdf
(150 bar)
and
https://www.cobham.com/mission-systems/composite-pressure-solutions/space-systems/xenon-propellant-tank-datasheet/
(85 bar)

So I suggest the lower value.