### PR TITLE
Remove misleading comment in Signal.cfg

### DIFF
--- a/GameData/KerbalismConfig/System/Signal.cfg
+++ b/GameData/KerbalismConfig/System/Signal.cfg
@@ -43,11 +43,6 @@
 	}
 }
 
-
-// ============================================================================
-// add Antenna to EVA suits
-// ============================================================================
-
 @PART[kerbalEVA*]:HAS[@MODULE[ModuleTripLogger]]:FOR[zzzKerbalismDefault]
 {
 	%MODULE[ModuleCommand]


### PR DESCRIPTION
That experiment that went well was removed but that misleading remaining comment is still there.