### PR TITLE
GravityRing: Fix reference to model file

### DIFF
--- a/GameData/KerbalismConfig/Parts/GravityRing/kerbalism-gravityring.cfg
+++ b/GameData/KerbalismConfig/Parts/GravityRing/kerbalism-gravityring.cfg
@@ -10,7 +10,7 @@ PART
 	category = Utility
 	subcategory = 0
 
-	mesh = NewModel.mu
+	mesh = model.mu
 	rescaleFactor = 1.0
 
 	attachRules = 1,0,1,0,0


### PR DESCRIPTION
Model file is model.mu, config file refers to NewModel.mu.

Not sure how this ever worked, since AFAICT the name has mismatched from the beginning, but I can confirm that it *did* work in previous versions of Kerbalism.