### PR TITLE
Duplicate RTG process due to US2 support patch

### DIFF
--- a/GameData/KerbalismConfig/Support/US2.cfg
+++ b/GameData/KerbalismConfig/Support/US2.cfg
@@ -170,3 +170,12 @@
   !MODULE[ModuleGenerator] {}
   !MODULE[ModuleCoreHeat] {}
 }
+
+@PART[USRTGWedge]:NEEDS[FeatureRadiation]:FOR[KerbalismDefault]
+{
+  MODULE
+  {
+    name = Emitter
+    radiation = 0.0000277775 // 0.1 rad/h
+  }
+}

--- a/GameData/KerbalismConfig/Support/US2.cfg
+++ b/GameData/KerbalismConfig/Support/US2.cfg
@@ -155,7 +155,7 @@
   }
 }
 
-@PART[rtg]:NEEDS[ProfileDefault]:FOR[KerbalismDefault]
+@PART[USRTGWedge]:NEEDS[ProfileDefault]:FOR[KerbalismDefault]
 {
   MODULE
   {


### PR DESCRIPTION
KerbalismConfig/Support/US2.cfg adds a duplicate _RTG ProcessController module to the **stock** RTG. The part name should be USRTGWedge instead.
