### PR TITLE
Fix automation and planner UI for Kerbalism (non-stock) harvesters

### DIFF
--- a/GameData/Kerbalism/Localization/de.cfg
+++ b/GameData/Kerbalism/Localization/de.cfg
@@ -556,6 +556,7 @@ Localization
     #KERBALISM_Harvester_running = running // UNTRANSLATED
     #KERBALISM_Harvester_stopped = stopped // UNTRANSLATED
     #KERBALISM_Harvester_none = none // UNTRANSLATED
+    #KERBALISM_Harvester_simulatedabundance = Simulate at abundance // UNTRANSLATED
     #KERBALISM_Harvester_land_valid = no ground contact // UNTRANSLATED
     #KERBALISM_Harvester_ocean_valid = not in ocean // UNTRANSLATED
     #KERBALISM_Harvester_atmo_valid = not in atmosphere // UNTRANSLATED

--- a/GameData/Kerbalism/Localization/en-us.cfg
+++ b/GameData/Kerbalism/Localization/en-us.cfg
@@ -556,6 +556,7 @@ Localization
     #KERBALISM_Harvester_running = running
     #KERBALISM_Harvester_stopped = stopped
     #KERBALISM_Harvester_none = none
+    #KERBALISM_Harvester_simulatedabundance = Simulate at abundance
     #KERBALISM_Harvester_land_valid = no ground contact
     #KERBALISM_Harvester_ocean_valid = not in ocean
     #KERBALISM_Harvester_atmo_valid = not in atmosphere

--- a/GameData/Kerbalism/Localization/es-es.cfg
+++ b/GameData/Kerbalism/Localization/es-es.cfg
@@ -556,6 +556,7 @@ Localization
     #KERBALISM_Harvester_running = running // UNTRANSLATED
     #KERBALISM_Harvester_stopped = stopped // UNTRANSLATED
     #KERBALISM_Harvester_none = none // UNTRANSLATED
+    #KERBALISM_Harvester_simulatedabundance = Simulate at abundance // UNTRANSLATED
     #KERBALISM_Harvester_land_valid = no ground contact // UNTRANSLATED
     #KERBALISM_Harvester_ocean_valid = not in ocean // UNTRANSLATED
     #KERBALISM_Harvester_atmo_valid = not in atmosphere // UNTRANSLATED

--- a/GameData/Kerbalism/Localization/pt-br.cfg
+++ b/GameData/Kerbalism/Localization/pt-br.cfg
@@ -556,6 +556,7 @@ Localization
     #KERBALISM_Harvester_running = running // UNTRANSLATED
     #KERBALISM_Harvester_stopped = stopped // UNTRANSLATED
     #KERBALISM_Harvester_none = none // UNTRANSLATED
+    #KERBALISM_Harvester_simulatedabundance = Simulate at abundance // UNTRANSLATED
     #KERBALISM_Harvester_land_valid = no ground contact // UNTRANSLATED
     #KERBALISM_Harvester_ocean_valid = not in ocean // UNTRANSLATED
     #KERBALISM_Harvester_atmo_valid = not in atmosphere // UNTRANSLATED

--- a/GameData/Kerbalism/Localization/ru.cfg
+++ b/GameData/Kerbalism/Localization/ru.cfg
@@ -556,6 +556,7 @@ Localization
     #KERBALISM_Harvester_running = running // UNTRANSLATED
     #KERBALISM_Harvester_stopped = stopped // UNTRANSLATED
     #KERBALISM_Harvester_none = none // UNTRANSLATED
+    #KERBALISM_Harvester_simulatedabundance = Simulate at abundance // UNTRANSLATED
     #KERBALISM_Harvester_land_valid = no ground contact // UNTRANSLATED
     #KERBALISM_Harvester_ocean_valid = not in ocean // UNTRANSLATED
     #KERBALISM_Harvester_atmo_valid = not in atmosphere // UNTRANSLATED

--- a/GameData/Kerbalism/Localization/zh-cn.cfg
+++ b/GameData/Kerbalism/Localization/zh-cn.cfg
@@ -556,6 +556,7 @@ Localization
     #KERBALISM_Harvester_running = 运行 // "running"
     #KERBALISM_Harvester_stopped = 停止 // "stopped"
     #KERBALISM_Harvester_none = 无 // "none"
+    #KERBALISM_Harvester_simulatedabundance = Simulate at abundance // UNTRANSLATED
     #KERBALISM_Harvester_land_valid = 没有触地 // "no ground contact"
     #KERBALISM_Harvester_ocean_valid = 不在海洋 // "not in ocean"
     #KERBALISM_Harvester_atmo_valid = 不在大气 // "not in atmosphere"

--- a/src/Kerbalism/Automation/Computer.cs
+++ b/src/Kerbalism/Automation/Computer.cs
@@ -250,6 +250,7 @@ namespace KERBALISM
 						case "Greenhouse":                   device = new GreenhouseDevice(m as Greenhouse);                     break;
 						case "GravityRing":                  device = new RingDevice(m as GravityRing);                          break;
 						case "Emitter":                      device = new EmitterDevice(m as Emitter);                           break;
+						case "Harvester":                    device = new HarvesterDevice(m as Harvester);                         break;
 						case "Laboratory":                   device = new LaboratoryDevice(m as Laboratory);                     break;
 						case "Experiment":                   device = new ExperimentDevice(m as Experiment);                     break;
 						case "SolarPanelFixer":				 device = new PanelDevice(m as SolarPanelFixer);					  break;
@@ -312,6 +313,7 @@ namespace KERBALISM
 							case "Greenhouse":                   device = new ProtoGreenhouseDevice(module_prefab as Greenhouse, p, m);            break;
 							case "GravityRing":                  device = new ProtoRingDevice(module_prefab as GravityRing, p, m);                 break;
 							case "Emitter":                      device = new ProtoEmitterDevice(module_prefab as Emitter, p, m);                  break;
+							case "Harvester":                    device = new ProtoHarvesterDevice(module_prefab as Harvester, p, m);              break;
 							case "Laboratory":                   device = new ProtoLaboratoryDevice(module_prefab as Laboratory, p, m);            break;
 							case "Experiment":					 device = new ProtoExperimentDevice(module_prefab as Experiment, p, m, v);         break;
 							case "SolarPanelFixer":              device = new ProtoPanelDevice(module_prefab as SolarPanelFixer, p, m);            break;

--- a/src/Kerbalism/Modules/Harvester.cs
+++ b/src/Kerbalism/Modules/Harvester.cs
@@ -29,6 +29,11 @@ namespace KERBALISM
 		// show abundance level
 		[KSPField(guiActive = false, guiName = "_")] public string Abundance;
 
+		// In the editor, allow the user to tweak the abundance for simulation purposes
+		[KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "#KERBALISM_Harvester_simulatedabundance")]
+		[UI_FloatRange(scene = UI_Scene.Editor, minValue = 0f, maxValue = 1f, stepIncrement = 0.01f)]
+		public float simulated_abundance = 0.1f;
+
 		// the drill head transform
 		Transform drill_head;
 

--- a/src/Kerbalism/Modules/Harvester.cs
+++ b/src/Kerbalism/Modules/Harvester.cs
@@ -99,7 +99,7 @@ namespace KERBALISM
 
 				ResourceRecipe recipe = new ResourceRecipe(ResourceBroker.Harvester);
 				recipe.AddInput("ElectricCharge", harvester.ec_rate * elapsed_s);
-				recipe.AddOutput(harvester.resource, harvester.rate * (abundance/harvester.abundance_rate) * elapsed_s, false);
+				recipe.AddOutput(harvester.resource, rate * (abundance/harvester.abundance_rate) * elapsed_s, false);
 				ResourceCache.AddRecipe(v, recipe);
 			}
 		}

--- a/src/Kerbalism/UI/Monitor.cs
+++ b/src/Kerbalism/UI/Monitor.cs
@@ -262,7 +262,6 @@ namespace KERBALISM
 
 		void Render_menu(Vessel v)
 		{
-			const string tooltip = "#KERBALISM_Monitor_tooltip";//"\n<i>(middle-click to popout in a window, middle-click again to close popout)</i>"
 			VesselData vd = v.KerbalismData();
 			GUILayout.BeginHorizontal(Styles.entry_container);
 			GUILayout.Label(new GUIContent(Lib.Color(page == MonitorPage.telemetry, " " + Local.Monitor_INFO, Lib.Kolor.Green, Lib.Kolor.None, true), Textures.small_info, Local.Monitor_INFO_desc + Local.Monitor_tooltip), config_style);//INFO"Telemetry readings"

--- a/src/Kerbalism/UI/Planner/ResourceSimulator.cs
+++ b/src/Kerbalism/UI/Planner/ResourceSimulator.cs
@@ -134,6 +134,9 @@ namespace KERBALISM.Planner
 							case "GravityRing":
 								Process_ring(m as GravityRing);
 								break;
+							case "Harvester":
+								Process_harvester(m as Harvester);
+								break;
 							case "Laboratory":
 								Process_laboratory(m as Laboratory);
 								break;
@@ -153,7 +156,7 @@ namespace KERBALISM.Planner
 								Process_converter(m as ModuleResourceConverter, va);
 								break;
 							case "ModuleResourceHarvester":
-								Process_harvester(m as ModuleResourceHarvester, va);
+								Process_stockharvester(m as ModuleResourceHarvester, va);
 								break;
 							case "ModuleScienceConverter":
 								Process_stocklab(m as ModuleScienceConverter);
@@ -442,6 +445,16 @@ namespace KERBALISM.Planner
 				Resource("ElectricCharge").Consume(ring.ec_rate, "gravity ring");
 		}
 
+		void Process_harvester(Harvester harvester)
+		{
+			if (harvester.running)
+			{
+				SimulatedRecipe recipe = new SimulatedRecipe(harvester.part, "harvester");
+				if (harvester.ec_rate > double.Epsilon) recipe.Input("ElectricCharge", harvester.ec_rate);
+				recipe.Output(harvester.resource, harvester.rate, true);
+				recipes.Add(recipe);
+			}
+		}
 
 		void Process_laboratory(Laboratory lab)
 		{
@@ -515,7 +528,7 @@ namespace KERBALISM.Planner
 		}
 
 
-		void Process_harvester(ModuleResourceHarvester harvester, VesselAnalyzer va)
+		void Process_stockharvester(ModuleResourceHarvester harvester, VesselAnalyzer va)
 		{
 			// calculate experience bonus
 			float exp_bonus = harvester.UseSpecialistBonus

--- a/src/Kerbalism/UI/Planner/ResourceSimulator.cs
+++ b/src/Kerbalism/UI/Planner/ResourceSimulator.cs
@@ -135,7 +135,7 @@ namespace KERBALISM.Planner
 								Process_ring(m as GravityRing);
 								break;
 							case "Harvester":
-								Process_harvester(m as Harvester);
+								Process_harvester(m as Harvester, va);
 								break;
 							case "Laboratory":
 								Process_laboratory(m as Laboratory);
@@ -445,13 +445,18 @@ namespace KERBALISM.Planner
 				Resource("ElectricCharge").Consume(ring.ec_rate, "gravity ring");
 		}
 
-		void Process_harvester(Harvester harvester)
+		void Process_harvester(Harvester harvester, VesselAnalyzer va)
 		{
 			if (harvester.running)
 			{
+				double simulatedAbundance = 0.10;
+
 				SimulatedRecipe recipe = new SimulatedRecipe(harvester.part, "harvester");
 				if (harvester.ec_rate > double.Epsilon) recipe.Input("ElectricCharge", harvester.ec_rate);
-				recipe.Output(harvester.resource, harvester.rate, true);
+				recipe.Output(
+					harvester.resource,
+					Harvester.AdjustedRate(harvester, new CrewSpecs("Engineer@0"), va.crew, simulatedAbundance),
+					dump: false);
 				recipes.Add(recipe);
 			}
 		}

--- a/src/Kerbalism/UI/Planner/ResourceSimulator.cs
+++ b/src/Kerbalism/UI/Planner/ResourceSimulator.cs
@@ -447,15 +447,13 @@ namespace KERBALISM.Planner
 
 		void Process_harvester(Harvester harvester, VesselAnalyzer va)
 		{
-			if (harvester.running)
+			if (harvester.running && harvester.simulated_abundance > harvester.min_abundance)
 			{
-				double simulatedAbundance = 0.10;
-
 				SimulatedRecipe recipe = new SimulatedRecipe(harvester.part, "harvester");
 				if (harvester.ec_rate > double.Epsilon) recipe.Input("ElectricCharge", harvester.ec_rate);
 				recipe.Output(
 					harvester.resource,
-					Harvester.AdjustedRate(harvester, new CrewSpecs("Engineer@0"), va.crew, simulatedAbundance),
+					Harvester.AdjustedRate(harvester, new CrewSpecs("Engineer@0"), va.crew, harvester.simulated_abundance),
 					dump: false);
 				recipes.Add(recipe);
 			}

--- a/src/Kerbalism/UI/Planner/VesselAnalyzer.cs
+++ b/src/Kerbalism/UI/Planner/VesselAnalyzer.cs
@@ -30,7 +30,7 @@ namespace KERBALISM.Planner
 			// get number of kerbals assigned to the vessel in the editor
 			// note: crew manifest is not reset after root part is deleted
 			VesselCrewManifest manifest = KSP.UI.CrewAssignmentDialog.Instance.GetManifest();
-			List<ProtoCrewMember> crew = manifest.GetAllCrew(false).FindAll(k => k != null);
+			crew = manifest.GetAllCrew(false).FindAll(k => k != null);
 			crew_count = (uint)crew.Count;
 			crew_engineer = crew.Find(k => k.trait == "Engineer") != null;
 			crew_scientist = crew.Find(k => k.trait == "Scientist") != null;
@@ -242,6 +242,7 @@ namespace KERBALISM.Planner
 
 
 		// general
+		public List<ProtoCrewMember> crew;                  // full information on all crew
 		public uint crew_count;                             // crew member on board
 		public uint crew_capacity;                          // crew member capacity
 		public bool crew_engineer;                          // true if an engineer is among the crew


### PR DESCRIPTION
In March 2018, 57977b30 (with the uniquely uninformative commit message "Weewoo") deleted Harvester.cs and all references to it.

Assorted commits tried to undo this, notably f17b3892 ("I have no idea how an entire module goes missing") and da1d2dc4 (which fixed background processing). However, the code which supported the Harvester module in the automation system and in the planning UI was never restored. This branch fixes those.