### PR TITLE
NearFuture HDD sizes

### DIFF
--- a/GameData/KerbalismConfig/Support/NFExploration_Science.cfg
+++ b/GameData/KerbalismConfig/Support/NFExploration_Science.cfg
@@ -99,3 +99,120 @@
 		radiation_decay_rate = 10
 	}
 }
+
+// Probe HDD sizes - d4harp
+// These are simple estimates based on size and tech tree level relative to stock probes
+@KERBALISM_HDD_SIZES:BEFORE[KerbalismDefault]:NEEDS[NearFutureExploration,!RP-0,FeatureScience]
+{
+	NearFutureExploration
+	{
+		rnd
+		{
+			hddSize = 32
+			sampleStorage = 0
+		}
+		dsk
+		{
+			hddSize = 512
+			sampleStorage = 0
+		}
+		rekt
+		{
+			hddSize = 512
+			sampleStorage = 0
+		}
+		stp
+		{
+			hddSize = 512
+			sampleStorage = 0
+		}
+		cyl
+		{
+			hddSize = 1024
+			sampleStorage = 0
+		}
+		sqr
+		{
+			hddSize = 1024
+			sampleStorage = 0
+		}
+		chfr
+		{
+			hddSize = 1024
+			sampleStorage = 0
+		}
+		plto
+		{
+			hddSize = 1024
+			sampleStorage = 0
+		}
+	}
+}
+
+// Apply probe HDD patches
+
+@PART[nfex-probe-chfr-1]:NEEDS[NearFutureExploration,FeatureScience]:AFTER[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/NearFutureExploration/chfr/hddSize$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/NearFutureExploration/chfr/sampleStorage$
+	}
+}
+@PART[nfex-probe-cyl-1]:NEEDS[NearFutureExploration,FeatureScience]:AFTER[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/NearFutureExploration/cyl/hddSize$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/NearFutureExploration/cyl/sampleStorage$
+	}
+}
+@PART[nfex-probe-dsk-1]:NEEDS[NearFutureExploration,FeatureScience]:AFTER[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/NearFutureExploration/dsk/hddSize$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/NearFutureExploration/dsk/sampleStorage$
+	}
+}
+@PART[nfex-probe-plto-1]:NEEDS[NearFutureExploration,FeatureScience]:AFTER[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/NearFutureExploration/plto/hddSize$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/NearFutureExploration/plto/sampleStorage$
+	}
+}
+
+@PART[nfex-probe-rkt-1]:NEEDS[NearFutureExploration,FeatureScience]:AFTER[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/NearFutureExploration/rekt/hddSize$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/NearFutureExploration/rekt/sampleStorage$
+	}
+}
+@PART[nfex-probe-rnd-1]:NEEDS[NearFutureExploration,FeatureScience]:AFTER[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/NearFutureExploration/rnd/hddSize$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/NearFutureExploration/rnd/sampleStorage$
+	}
+}
+@PART[nfex-probe-sqr-1]:NEEDS[NearFutureExploration,FeatureScience]:AFTER[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/NearFutureExploration/sqr/hddSize$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/NearFutureExploration/sqr/sampleStorage$
+	}
+}
+@PART[nfex-probe-stp-1]:NEEDS[NearFutureExploration,FeatureScience]:AFTER[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/NearFutureExploration/stp/hddSize$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/NearFutureExploration/stp/sampleStorage$
+	}
+}

--- a/GameData/KerbalismConfig/Support/NFSpacecraft_Science.cfg
+++ b/GameData/KerbalismConfig/Support/NFSpacecraft_Science.cfg
@@ -183,16 +183,16 @@
 {
     @MODULE[HardDrive]
     {
-        @dataCapacity = #$@KERBALISM_HDD_SIZES/NearFutureSpacecraft/calissto/hddSize$
-        @sampleCapacity = #$@KERBALISM_HDD_SIZES/NearFutureSpacecraft/calissto/sampleStorage$
+        @dataCapacity = #$@KERBALISM_HDD_SIZES/NearFutureSpacecraft/elara/hddSize$
+        @sampleCapacity = #$@KERBALISM_HDD_SIZES/NearFutureSpacecraft/elara/sampleStorage$
     }
 }
 @PART[command-pdd-1]:NEEDS[NearFutureSpacecraft,FeatureScience]:AFTER[KerbalismDefault]
 {
     @MODULE[HardDrive]
     {
-        @dataCapacity = #$@KERBALISM_HDD_SIZES/NearFutureSpacecraft/elar/hddSize$
-        @sampleCapacity = #$@KERBALISM_HDD_SIZES/NearFutureSpacecraft/elara/sampleStorage$
+        @dataCapacity = #$@KERBALISM_HDD_SIZES/NearFutureSpacecraft/calissto/hddSize$
+        @sampleCapacity = #$@KERBALISM_HDD_SIZES/NearFutureSpacecraft/calissto/sampleStorage$
     }
 }
 


### PR DESCRIPTION
- Define HDD size for the new NearFutureExploration probes. The values are simple estimates based on existing values on the stock probes. Feel free to adjust if it feels unbalanced.

- Fix a minor typo in the NearFutureSpacecraft HDD patches.