### PR TITLE
XL3 rover wheel planner support

### DIFF
--- a/GameData/KerbalismConfig/System/Planner.cfg
+++ b/GameData/KerbalismConfig/System/Planner.cfg
@@ -68,7 +68,8 @@
 }
 
 
-@PART[*]:HAS[@MODULE[ModuleWheelMotor]]:FOR[KerbalismDefault]
+// Note : using wildcard ModuleWheelMotor* to also catch ModuleWheelMotorSteering
+@PART[*]:HAS[@MODULE[ModuleWheelMotor*]]:FOR[KerbalismDefault]
 {
   MODULE
   {


### PR DESCRIPTION
The XL3 rover wheels use ModuleWheelMotorSteering instead of ModuleWheelMotor. This change adds PlannerController modules to all parts matching wildcard ModuleWheelMotor*