### PR TITLE
Prevent patching engine reliability if PayToPlay mod is installed

### DIFF
--- a/GameData/KerbalismConfig/System/Reliability.cfg
+++ b/GameData/KerbalismConfig/System/Reliability.cfg
@@ -444,7 +444,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleEngines*],!MODULE[Reliability]:HAS[#type[ModuleEngines]]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
+@PART[*]:HAS[@MODULE[ModuleEngines*],!MODULE[Reliability]:HAS[#type[ModuleEngines]]]:NEEDS[FeatureReliability&!PayToPlay]:FOR[KerbalismDefault]
 {
 	MODULE
 	{
@@ -453,7 +453,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleEngines*]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
+@PART[*]:HAS[@MODULE[ModuleEngines*]]:NEEDS[FeatureReliability&!PayToPlay]:FOR[KerbalismDefault]
 {
 	@MODULE[Reliability]:HAS[#type[ModuleEngines*]]
 	{
@@ -475,7 +475,7 @@
 // thrust 0-350 gives 64-1 ignitions (custom exponential-ish scale).
 // vac/atm ratio gives no bonus if below 150%, and then a linear bonus of +1 ignitions for every extra 20%.
 // some specific engine types will receive further bonus.
-@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[#maxThrust,@atmosphereCurve]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
+@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[#maxThrust,@atmosphereCurve]]:NEEDS[FeatureReliability&!PayToPlay]:FOR[KerbalismDefault]
 {
 	@MODULE[Reliability]
 	{
@@ -549,7 +549,7 @@
 }
 
 // SRBs
-@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[SolidFuel]]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
+@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[SolidFuel]]]:NEEDS[FeatureReliability&!PayToPlay]:FOR[KerbalismDefault]
 {
 	@MODULE[Reliability]
 	{
@@ -560,7 +560,7 @@
 }
 
 // NERV
-@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel]]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
+@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel]]]:NEEDS[FeatureReliability&!PayToPlay]:FOR[KerbalismDefault]
 {
 	@MODULE[Reliability]
 	{
@@ -570,7 +570,7 @@
 }
 
 // your standard garden variety rocket engine
-@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[Oxidizer]]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
+@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[Oxidizer]]]:NEEDS[FeatureReliability&!PayToPlay]:FOR[KerbalismDefault]
 {
 	@MODULE[Reliability]
 	{
@@ -581,7 +581,7 @@
 }
 
 // ion engines
-@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[XenonGas]]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
+@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[XenonGas]]]:NEEDS[FeatureReliability&!PayToPlay]:FOR[KerbalismDefault]
 {
 	@MODULE[Reliability] {
 		@rated_operation_duration = 0
@@ -591,7 +591,7 @@
 }
 
 // jet engines
-@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[IntakeAir]]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
+@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[IntakeAir]]]:NEEDS[FeatureReliability&!PayToPlay]:FOR[KerbalismDefault]
 {
 	@MODULE[Reliability] {
 		@rated_operation_duration = 86400
@@ -601,7 +601,7 @@
 }
 
 // hypergolic or monoprop engines
-@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[MonoPropellant]]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
+@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[MonoPropellant]]]:NEEDS[FeatureReliability&!PayToPlay]:FOR[KerbalismDefault]
 {
 	@MODULE[Reliability] {
 		@rated_operation_duration = 0
@@ -611,7 +611,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleEnginesRF]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
+@PART[*]:HAS[@MODULE[ModuleEnginesRF]]:NEEDS[FeatureReliability&!PayToPlay]:FOR[KerbalismDefault]
 {
 	MODULE
 	{


### PR DESCRIPTION
Hi there! I have recently started a new (and the first for me) reliability mod called PayToPlay. The main purpose is to make the player pay for engines maintenance. As for now it is in a deep WIP stage (but you can try it out on engines that are provided with configs or make configs on your own). I wish everything to be ready by the time I finish the initial stage of developing the mod. So I start this PR to prevent engines from being patched by kerbalism and "unpatched", causing extra loading time.

Here is a link to the mod repo: https://github.com/DarthPointer/PayToPlay (no forum thread yet).