### PR TITLE
Solar storms bugfix/additions

### DIFF
--- a/src/Kerbalism/Database/VesselHabitatInfo.cs
+++ b/src/Kerbalism/Database/VesselHabitatInfo.cs
@@ -125,17 +125,18 @@ namespace KERBALISM
 					// to many GeV (the fastest particles can approach the speed of light, as in a
 					// "ground-level event"). This is why they are such a big problem for interplanetary space travel.
 
-					// We just assume a big halfing thickness for that kind of ionized radiation.
-					var halfingThickness = 1.0;
+					// Beer-Lambert law: Remaining radiation = radiation * e^-ux.  Not exact for SEP, but close enough to loosely fit observed curves.
+					// linear attenuation coefficent u.  Asssuming an average CME event energy Al shielding 10 ~= 30 g/cm^2.
+					// Averaged from NASA plots of large CME events vs Al shielding projections.
+					var linearAttenuation = 10; 
 
-					// halfing factor h = part thickness / halfing thickness
-					// remaining radiation = radiation / (2^h)
-					// However, what you loose in particle radiation you gain in gamma radiation (Bremsstrahlung)
+					// However, what you lose in particle radiation you gain in gamma radiation (Bremsstrahlung)
 
-					var bremsstrahlung = remainingRadiation / Math.Pow(2, shieldingInfo.thickness / halfingThickness);
-					remainingRadiation -= bremsstrahlung;
+					var incomingRadiation = remainingRadiation;
+					remainingRadiation *= Math.Exp(shieldingInfo.thickness * linearAttenuation * -1);
+					var bremsstrahlung = incomingRadiation - remainingRadiation;
 
-					result += Radiation.DistanceRadiation(bremsstrahlung, shieldingInfo.distance);
+					result += Radiation.DistanceRadiation(bremsstrahlung, Math.Max(1,shieldingInfo.distance)) / 10; //Gamma radiation has 1/10 the quality factor of SEP
 				}
 
 				result += remainingRadiation;


### PR DESCRIPTION
This is a bugfix/addition to the solar storm shielding code.  The existing code is producing some odd/unrealistic results which I believe is down to 3 factors.  

1) The bremsstrahlung formula is inverted.  It goes to infinity at 0 shield mass.  
2) Bremsstrahlung is gamma radiation, which has a rad to rem conversion of 1/10 that of SEP.
https://www.nrc.gov/reading-rm/doc-collections/cfr/part020/part020-1004.html
3) source/receiver distance is being determined by a raycast, which is 0 for adjacent parts, making directly attached shielding useless when combined with issue 2.

Fixes:
1) Use exponential attenuation formula for bremsstrahlung generation
2) Divide bremsstrahlung by 10
3) Use minimum source distance of 1m, making the assumption that the kerbals can get at least that far away from a wall.  This still doesn't account for shield thickness, but plays well enough.

I've tested this in RP-1 with Standecco's proposed RP-1 storm settings and it played fairly realistically.  Mars opposition mission was barely feasible with several tons of extra shielding.  Lunar base missions were easy with dedicated proton shielding, and impossible without them.

For reference, I eyeballed the new linear attenuation coefficient from figure 9 here:  https://www.nrc.gov/reading-rm/doc-collections/cfr/part020/part020-1004.html.   Perhaps this should be affected by the shielding difficulty slider?