### PR TITLE
Fix Execution error for null value in Contract

### DIFF
--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -205,6 +205,15 @@
 	}
 }
 
+//  Changes experimentlist to accomodate change in experiment_id
+@CONTRACT_TYPE[BDB_Gemini]:NEEDS[Bluedog_DB,FeatureScience]
+{
+	@DATA[experimentslist]
+	{
+		%experiments = [logmmImpacts, geigerCounter]
+	}
+}
+
 // ============================================================================
 // Give early IDCSP relay more EC to survive more than 5 minutes in the dark
 // but not too much, and do not increase the solar panel output


### PR DESCRIPTION
Kerbalism changed the BDB experimentID in the parts but never changed the contract to account for it.
This causes experimentID to have a null value and generate an EXC error.