### PR TITLE
Fix stock bug with module generator in launch clamp and is always active = false

### DIFF
--- a/GameData/KerbalismConfig/Support/ReStock.cfg
+++ b/GameData/KerbalismConfig/Support/ReStock.cfg
@@ -15,4 +15,10 @@
 	{
 		%isAlwaysActive = true
 	}
+
+	// this seems to be the culprit, the planner in VAB does not work when the initial setting is 'true'
+	@MODULE[PlannerController]
+	{
+		@considered = false
+	}
 }

--- a/GameData/KerbalismConfig/Support/ReStock.cfg
+++ b/GameData/KerbalismConfig/Support/ReStock.cfg
@@ -1,0 +1,18 @@
+@PART[*]:HAS[@MODULE[ModuleRestockLaunchClamp],@MODULE[Habitat],#CrewCapacity[>0]]:AFTER[KerbalismDefault]:NEEDS[FeatureHabitat,ReStock]
+{
+	@MODULE[Habitat]
+	{
+		state = disabled
+	}
+}
+
+// to fix a stock bug that there is no toggle button ob the part's PAW
+// when ModuleGenerator got isAlwaysActive = false
+// it will be set to 'true' for now
+@PART[*]:HAS[@MODULE[ModuleGenerator],@MODULE[ModuleRestockLaunchClamp]]:AFTER[KerbalismDefault]
+{
+	@MODULE[ModuleGenerator]:HAS[~isAlwaysActive[true]]
+	{
+		%isAlwaysActive = true
+	}
+}

--- a/GameData/KerbalismConfig/Support/ReStock.cfg
+++ b/GameData/KerbalismConfig/Support/ReStock.cfg
@@ -9,7 +9,7 @@
 // to fix a stock bug that there is no toggle button ob the part's PAW
 // when ModuleGenerator got isAlwaysActive = false
 // it will be set to 'true' for now
-@PART[*]:HAS[@MODULE[ModuleGenerator],@MODULE[ModuleRestockLaunchClamp]]:AFTER[KerbalismDefault]
+@PART[*]:HAS[@MODULE[ModuleGenerator],@MODULE[ModuleRestockLaunchClamp]]:AFTER[zzzKerbalismDefault]
 {
 	@MODULE[ModuleGenerator]:HAS[~isAlwaysActive[true]]
 	{

--- a/GameData/KerbalismConfig/System/Planner.cfg
+++ b/GameData/KerbalismConfig/System/Planner.cfg
@@ -35,6 +35,17 @@
   }
 }
 
+// to fix a stock bug that there is no toggle button ob the part's PAW
+// when ModuleGenerator got isAlwaysActive = false
+// it will be set to 'true' for now
+@PART[*]:HAS[@MODULE[ModuleGenerator],@MODULE[LaunchClamp],!MODULE[Habitat]]:AFTER[KerbalismDefault]
+{
+	@MODULE[ModuleGenerator]:HAS[~isAlwaysActive[true]]
+	{
+		%isAlwaysActive = true
+	}
+}
+
 @PART[*]:HAS[@MODULE[ModuleResourceConverter]]:FOR[KerbalismDefault]
 {
   MODULE

--- a/GameData/KerbalismConfig/System/Planner.cfg
+++ b/GameData/KerbalismConfig/System/Planner.cfg
@@ -38,7 +38,7 @@
 // to fix a stock bug that there is no toggle button ob the part's PAW
 // when ModuleGenerator got isAlwaysActive = false
 // it will be set to 'true' for now
-@PART[*]:HAS[@MODULE[ModuleGenerator],@MODULE[LaunchClamp]]:AFTER[KerbalismDefault]
+@PART[*]:HAS[@MODULE[ModuleGenerator],@MODULE[LaunchClamp]]:AFTER[zzzKerbalismDefault]
 {
 	@MODULE[ModuleGenerator]:HAS[~isAlwaysActive[true]]
 	{

--- a/GameData/KerbalismConfig/System/Planner.cfg
+++ b/GameData/KerbalismConfig/System/Planner.cfg
@@ -38,7 +38,7 @@
 // to fix a stock bug that there is no toggle button ob the part's PAW
 // when ModuleGenerator got isAlwaysActive = false
 // it will be set to 'true' for now
-@PART[*]:HAS[@MODULE[ModuleGenerator],@MODULE[LaunchClamp]]:AFTER[zzzKerbalismDefault]
+@PART[*]:HAS[@MODULE[ModuleGenerator],@MODULE[LaunchClamp]]:AFTER[KerbalismDefault]
 {
 	@MODULE[ModuleGenerator]:HAS[~isAlwaysActive[true]]
 	{

--- a/GameData/KerbalismConfig/System/Planner.cfg
+++ b/GameData/KerbalismConfig/System/Planner.cfg
@@ -38,7 +38,7 @@
 // to fix a stock bug that there is no toggle button ob the part's PAW
 // when ModuleGenerator got isAlwaysActive = false
 // it will be set to 'true' for now
-@PART[*]:HAS[@MODULE[ModuleGenerator],@MODULE[LaunchClamp],!MODULE[Habitat]]:AFTER[KerbalismDefault]
+@PART[*]:HAS[@MODULE[ModuleGenerator],@MODULE[LaunchClamp]]:AFTER[KerbalismDefault]
 {
 	@MODULE[ModuleGenerator]:HAS[~isAlwaysActive[true]]
 	{


### PR DESCRIPTION
The is no button to toggle on the PAW so when it's off it's off and so the planner button to toggle consideration is useless.

Solution:
always active = true

Modules:
LaunchClamp
ModuleRestockLaunchClamp

which got a ModuleGenerator.
