### PR TITLE
Tiny addition to the Engine Ignitor config

### DIFF
--- a/GameData/KerbalismConfig/Support/EngineIgnitor.cfg
+++ b/GameData/KerbalismConfig/Support/EngineIgnitor.cfg
@@ -1,5 +1,5 @@
 // disable all engine failures
-@PART[*]:HAS[@MODULE[ModuleEngines*]]:NEEDS[EngineIgnitor]:AFTER[Kerbalism]
+@PART[*]:HAS[@MODULE[ModuleEngines*]]:NEEDS[EngineIgnitor]:NEEDS[!KiwiTechTree]:AFTER[Kerbalism]
 {
   !MODULE[Reliability],* {}
 }

--- a/GameData/KerbalismConfig/Support/EngineIgnitor.cfg
+++ b/GameData/KerbalismConfig/Support/EngineIgnitor.cfg
@@ -1,5 +1,5 @@
 // disable all engine failures
 @PART[*]:HAS[@MODULE[ModuleEngines*]]:NEEDS[EngineIgnitor,!KiwiTechTree]:AFTER[Kerbalism]
 {
-  !MODULE[Reliability],* {}
+  !MODULE[Reliability]:HAS[#type[ModuleEngines*]] {} 
 }

--- a/GameData/KerbalismConfig/Support/EngineIgnitor.cfg
+++ b/GameData/KerbalismConfig/Support/EngineIgnitor.cfg
@@ -1,5 +1,5 @@
 // disable all engine failures
-@PART[*]:HAS[@MODULE[ModuleEngines*]]:NEEDS[EngineIgnitor]:NEEDS[!KiwiTechTree]:AFTER[Kerbalism]
+@PART[*]:HAS[@MODULE[ModuleEngines*]]:NEEDS[EngineIgnitor,!KiwiTechTree]:AFTER[Kerbalism]
 {
   !MODULE[Reliability],* {}
 }


### PR DESCRIPTION
Allows Kiwi Tech Tree to remove just the ignition and rated burn time features if Engine Ignitor is installed, instead of the whole engine failures feature.