### PR TITLE
Update Reliability.cfg

### DIFF
--- a/GameData/KerbalismConfig/System/Reliability.cfg
+++ b/GameData/KerbalismConfig/System/Reliability.cfg
@@ -467,7 +467,7 @@
 // some specific engine types will receive further bonus.
 @PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[#maxThrust,@atmosphereCurve]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
 {
-	@MODULE[Reliability]
+	@MODULE[Reliability]:HAS[#type[ModuleEngines*]]
 	{
 		// Parse and store atmosphere ISP as a temporary value
 		__tmp_isp_atm = #$../MODULE[ModuleEngines*]/atmosphereCurve/key,1$
@@ -541,7 +541,7 @@
 // SRBs
 @PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[SolidFuel]]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
 {
-	@MODULE[Reliability]
+	@MODULE[Reliability]:HAS[#type[ModuleEngines*]]
 	{
 		@rated_ignitions = 0
 		@rated_operation_duration = 0
@@ -552,7 +552,7 @@
 // NERV
 @PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel]]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
 {
-	@MODULE[Reliability]
+	@MODULE[Reliability]:HAS[#type[ModuleEngines*]]
 	{
 		@rated_operation_duration = 800
 		@repair = Engineer@2
@@ -562,7 +562,7 @@
 // your standard garden variety rocket engine
 @PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[Oxidizer]]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
 {
-	@MODULE[Reliability]
+	@MODULE[Reliability]:HAS[#type[ModuleEngines*]]
 	{
 		@rated_operation_duration = 350
 		@turnon_failure_probability = 0.007
@@ -573,7 +573,7 @@
 // ion engines
 @PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[XenonGas]]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
 {
-	@MODULE[Reliability] {
+	@MODULE[Reliability]:HAS[#type[ModuleEngines*]] {
 		@rated_operation_duration = 0
 		@turnon_failure_probability = 0.002
 		@repair = Engineer@2
@@ -583,7 +583,7 @@
 // jet engines
 @PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[IntakeAir]]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
 {
-	@MODULE[Reliability] {
+	@MODULE[Reliability]:HAS[#type[ModuleEngines*]] {
 		@rated_operation_duration = 86400
 		@rated_ignitions = 0
 		@repair = true
@@ -593,7 +593,7 @@
 // hypergolic or monoprop engines
 @PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[MonoPropellant]]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
 {
-	@MODULE[Reliability] {
+	@MODULE[Reliability]:HAS[#type[ModuleEngines*]] {
 		@rated_operation_duration = 0
 		@rated_ignitions = 0
 		@repair = true


### PR DESCRIPTION
Better targets the reliability patches for parts that have multiple Reliability modules (ie. Knes service modules).