### PR TITLE
Fixing kerbalism-container-radial-box-prosemian-normal mass

### DIFF
--- a/GameData/KerbalismConfig/Parts/ProsimianProductions/Containers/kerbalism-container-radial-box-prosemian-normal.cfg
+++ b/GameData/KerbalismConfig/Parts/ProsimianProductions/Containers/kerbalism-container-radial-box-prosemian-normal.cfg
@@ -33,7 +33,7 @@ PART
 	TechRequired = spaceExploration
 	entryCost = 800
 	cost = 250
-	mass = 0.000225
+	mass = 0.007
 
 	MODEL
 	{


### PR DESCRIPTION
Fix for https://github.com/Kerbalism/Kerbalism/issues/621

The mass for normal life support container is smaller than the small container, so this change is to fix that bug by scaling it up.

Formula for Surface Area of a Cube: A=6 * (edge) ^ 2

I deteremined the mass of the normal container by looking at the ratio of the small mass to surface area and large mass to surface area, and then average the differerence of the ratios.  This should account for the thickness of the container increasing as it's size increases.

Small
ContainerVolume = 10
mass = 0.0012
Voume to Mass Ratio: 8333.33

Normal
ContainerVolume = 85
mass = 0.007
Volume to Mass Ratio: 12142.85

Large
ContainerVolume = 678
mass = 0.036
Volumen to Mass Ratio: 18833.33


https://github.com/Kerbalism/Kerbalism/blob/b02a17b5dfc1c0ba4bb5a2db03452f029d9d0eb4/GameData/KerbalismConfig/Parts/ProsimianProductions/Containers/kerbalism-container-radial-box-prosemian-small.cfg#L36

https://github.com/Kerbalism/Kerbalism/blob/b02a17b5dfc1c0ba4bb5a2db03452f029d9d0eb4/GameData/KerbalismConfig/Parts/ProsimianProductions/Containers/kerbalism-container-radial-box-prosemian-normal.cfg#L36

https://github.com/Kerbalism/Kerbalism/blob/b02a17b5dfc1c0ba4bb5a2db03452f029d9d0eb4/GameData/KerbalismConfig/Parts/ProsimianProductions/Containers/kerbalism-container-radial-box-prosemian-large.cfg#L36