### PR TITLE
Improved automated configs for Orion, ATV, Soyuz and Progress. 

### DIFF
--- a/GameData/KerbalismConfig/Support/Knes_ATV.cfg
+++ b/GameData/KerbalismConfig/Support/Knes_ATV.cfg
@@ -1,0 +1,366 @@
+// Improving automated configuration to allow more realisitc resupply missions. Preconfigured the 5 original ATVs.
+
+B9_TANK_TYPE
+{
+	name = ATV1
+	tankMass =  0.00010627500
+	tankCost = 0.15
+	primaryColor = Azure
+
+	RESOURCE
+	{
+		name = Water
+		unitsPerVolume = 0.112
+		percentFilled = 33.33333333
+	}
+	RESOURCE
+	{
+		name = Food
+		unitsPerVolume = 1.03619177
+		percentFilled = 33.33333333
+	}
+	RESOURCE
+	{
+		name = Oxygen
+		unitsPerVolume = 9.45626478
+		percentFilled = 100
+	}
+	RESOURCE
+	{
+		name = Nitrogen
+		unitsPerVolume = 10.65814015
+		percentFilled = 0
+	}
+	RESOURCE
+	{
+		name = MonoPropellant
+		unitsPerVolume = 0.15666666
+		percentFilled = 47.87
+	}
+	RESOURCE
+	{
+		name = LiquidFuel
+		unitsPerVolume = 0.01013333
+		percentFilled = 100
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		unitsPerVolume = 0.01238519
+		percentFilled = 100
+	}
+	RESOURCE
+	{
+		name = Waste
+		unitsPerVolume = 0.97777777
+		percentFilled = 0
+	}
+	RESOURCE
+	{
+		name = WasteWater
+		unitsPerVolume = 0.11144278
+		percentFilled = 0
+	}
+}
+
+B9_TANK_TYPE
+{
+	name = ATV2
+	tankMass =  0.00010627500
+	tankCost = 0.15
+	primaryColor = Avocado
+
+	RESOURCE
+	{
+		name = Water
+		unitsPerVolume = 0.112
+		percentFilled = 0
+	}
+	RESOURCE
+	{
+		name = Food
+		unitsPerVolume = 1.03619177
+		percentFilled = 0
+	}
+	RESOURCE
+	{
+		name = Oxygen
+		unitsPerVolume = 9.45626478
+		percentFilled = 100
+	}
+	RESOURCE
+	{
+		name = Nitrogen
+		unitsPerVolume = 10.65814015
+		percentFilled = 0
+	}
+	RESOURCE
+	{
+		name = MonoPropellant
+		unitsPerVolume = 0.15666666
+		percentFilled = 96.49
+	}
+	RESOURCE
+	{
+		name = LiquidFuel
+		unitsPerVolume = 0.01013333
+		percentFilled = 100
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		unitsPerVolume = 0.01238519
+		percentFilled = 100
+	}
+	RESOURCE
+	{
+		name = Waste
+		unitsPerVolume = 0.97777777
+		percentFilled = 0
+	}
+	RESOURCE
+	{
+		name = WasteWater
+		unitsPerVolume = 0.11144278
+		percentFilled = 0
+	}
+}
+
+B9_TANK_TYPE
+{
+	name = ATV3
+	tankMass =  0.00010627500
+	tankCost = 0.15
+	primaryColor = Aubergine
+
+	RESOURCE
+	{
+		name = Water
+		unitsPerVolume = 0.112
+		percentFilled = 33.33333333
+	}
+	RESOURCE
+	{
+		name = Food
+		unitsPerVolume = 1.03619177
+		percentFilled = 33.33333333
+	}
+	RESOURCE
+	{
+		name = Oxygen
+		unitsPerVolume = 9.45626478
+		percentFilled = 100
+	}
+	RESOURCE
+	{
+		name = Nitrogen
+		unitsPerVolume = 10.65814015
+		percentFilled = 0
+	}
+	RESOURCE
+	{
+		name = MonoPropellant
+		unitsPerVolume = 0.15666666
+		percentFilled = 67.02
+	}
+	RESOURCE
+	{
+		name = LiquidFuel
+		unitsPerVolume = 0.01013333
+		percentFilled = 100
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		unitsPerVolume = 0.01238519
+		percentFilled = 100
+	}
+	RESOURCE
+	{
+		name = Waste
+		unitsPerVolume = 0.97777777
+		percentFilled = 0
+	}
+	RESOURCE
+	{
+		name = WasteWater
+		unitsPerVolume = 0.11144278
+		percentFilled = 0
+	}
+}
+
+B9_TANK_TYPE
+{
+	name = ATV4
+	tankMass =  0.00010627500
+	tankCost = 0.15
+	primaryColor = Banana
+
+	RESOURCE
+	{
+		name = Water
+		unitsPerVolume = 0.112
+		percentFilled = 66.66666666
+	}
+	RESOURCE
+	{
+		name = Food
+		unitsPerVolume = 1.03619177
+		percentFilled = 33.33333333
+	}
+	RESOURCE
+	{
+		name = Oxygen
+		unitsPerVolume = 9.45626478
+		percentFilled = 100
+	}
+	RESOURCE
+	{
+		name = Nitrogen
+		unitsPerVolume = 10.65814015
+		percentFilled = 0
+	}
+	RESOURCE
+	{
+		name = MonoPropellant
+		unitsPerVolume = 0.15666666
+		percentFilled = 52.02
+	}
+	RESOURCE
+	{
+		name = LiquidFuel
+		unitsPerVolume = 0.01013333
+		percentFilled = 100
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		unitsPerVolume = 0.01238519
+		percentFilled = 100
+	}
+	RESOURCE
+	{
+		name = Waste
+		unitsPerVolume = 0.97777777
+		percentFilled = 0
+	}
+	RESOURCE
+	{
+		name = WasteWater
+		unitsPerVolume = 0.11144278
+		percentFilled = 0
+	}
+}
+
+B9_TANK_TYPE
+{
+	name = ATV5
+	tankMass =  0.00010627500
+	tankCost = 0.15
+	primaryColor = BloodOrange
+
+	RESOURCE
+	{
+		name = Water
+		unitsPerVolume = 0.112
+		percentFilled = 100
+	}
+	RESOURCE
+	{
+		name = Food
+		unitsPerVolume = 1.03619177
+		percentFilled = 33.33333333
+	}
+	RESOURCE
+	{
+		name = Oxygen
+		unitsPerVolume = 9.45626478
+		percentFilled = 100
+	}
+	RESOURCE
+	{
+		name = Nitrogen
+		unitsPerVolume = 10.65814015
+		percentFilled = 0
+	}
+	RESOURCE
+	{
+		name = MonoPropellant
+		unitsPerVolume = 0.15666666
+		percentFilled = 42.40
+	}
+	RESOURCE
+	{
+		name = LiquidFuel
+		unitsPerVolume = 0.01013333
+		percentFilled = 100
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		unitsPerVolume = 0.01238519
+		percentFilled = 100
+	}
+	RESOURCE
+	{
+		name = Waste
+		unitsPerVolume = 0.97777777
+		percentFilled = 0
+	}
+	RESOURCE
+	{
+		name = WasteWater
+		unitsPerVolume = 0.11144278
+		percentFilled = 0
+	}
+}
+
+@PART[_Knes_ATV_Cargo]:NEEDS[Knes,B9PartSwitch,ProfileDefault]:BEFORE[KerbalismDefault]
+{
+	!CrewCapacity = 2
+	!RESOURCE[MonoPropellant] {}
+}
+
+@PART[_Knes_ATV_Cargo]:NEEDS[Knes,B9PartSwitch,ProfileDefault]:AFTER[KerbalismDefault]
+{
+	!MODULE[Configure] {}
+
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = fuelSwitch
+		baseVolume = 7500
+		switcherDescription = ATV Type
+
+		SUBTYPE
+		{
+			name = ATV1
+			title = Jules Verne
+			tankType = ATV1
+		}
+		SUBTYPE
+		{
+			name = ATV2
+			title = Johannes Kepler
+			tankType = ATV2
+		}
+		SUBTYPE
+		{
+			name = ATV3
+			title = Edoardo Amaldi
+			tankType = ATV3
+		}
+		SUBTYPE
+		{
+			name = ATV4
+			title = Albert Einstein
+			tankType = ATV4
+		}
+		SUBTYPE
+		{
+			name = ATV5
+			title = Georges Lemaitre
+			tankType = ATV5
+		}
+	}
+}

--- a/GameData/KerbalismConfig/Support/Tantares.cfg
+++ b/GameData/KerbalismConfig/Support/Tantares.cfg
@@ -137,4 +137,118 @@
 	!MODULE[ModuleScienceExperiment]:HAS[#experimentID[tantares_multispectral_scan]] {}
 }
 
+// Improving the automatic generated config for Tantares Progress M and Soyus TM/MS to allow more realistic mission times and resupply missions.
 
+@PART[hamal_orbital_module_s1_1]:NEEDS[Tantares,ProfileDefault]:BEFORE[KerbalismDefault]
+{
+	!CrewCapacity = 1
+}
+
+@PART[hamal_orbital_module_s1_1]:NEEDS[Tantares,ProfileDefault]:AFTER[KerbalismDefault]
+{
+	!MODULE[Configure] {}
+
+	RESOURCE
+	{
+		name = Oxygen
+		amount = 35461
+		maxAmount = 35461
+	}
+	RESOURCE
+	{
+		name = Nitrogen
+		amount = 0
+		maxAmount = 39968
+	}
+	RESOURCE
+	{
+		name = Food
+		amount = 1943
+		maxAmount = 1943
+	}
+	RESOURCE
+	{
+		name = Waste
+		amount = 0
+		maxAmount = 2133
+	}
+}
+
+@PART[hamal_avionics_s1_1]:NEEDS[Tantares,ProfileDefault]:AFTER[KerbalismDefault]
+{
+	!MODULE[Configure] {}
+	!RESOURCE[LiquidFuel] {}
+	!RESOURCE[Oxidizer] {}
+
+	RESOURCE
+	{
+		name = Water
+		amount = 420
+		maxAmount = 420
+	}
+	RESOURCE
+	{
+		name = WasteWater
+		amount = 0
+		maxAmount = 398
+	}
+	RESOURCE
+	{
+		name = LiquidFuel
+		amount = 99
+		maxAmount = 99
+	}
+	RESOURCE
+	{
+		name = Oxidizer
+		amount = 121
+		maxAmount = 121
+	}
+}
+
+
+@PART[tantares_orbital_module_s1_3]:NEEDS[Tantares,ProfileDefault]:AFTER[KerbalismDefault]
+{
+	!MODULE[Configure] {}
+	!RESOURCE[Water] {}
+	!RESOURCE[Food] {}
+	!RESOURCE[Oxygen] {}
+	!RESOURCE[Nitrogen] {}
+
+	RESOURCE
+	{
+		name = Water
+		amount = 8
+		maxAmount = 8
+	}
+	RESOURCE
+	{
+		name = Food
+		amount = 20
+		maxAmount = 20
+	}
+	RESOURCE
+	{
+		name = Oxygen
+		amount = 2200
+		maxAmount = 2200
+	}
+	RESOURCE
+	{
+		name = Nitrogen
+		amount = 1325
+		maxAmount = 1325
+	}
+	RESOURCE
+	{
+		name = WasteWater
+		amount = 0
+		maxAmount = 8
+	}
+	RESOURCE
+	{
+		name = Waste
+		amount = 0
+		maxAmount = 20
+	}
+}

--- a/GameData/KerbalismConfig/Support/reDirect_Orion.cfg
+++ b/GameData/KerbalismConfig/Support/reDirect_Orion.cfg
@@ -1,0 +1,43 @@
+// Improving automated config for Orion capsule to allow more realisitc mission times
+
+@PART[DIRECT_orion_ServiceModule]:NEEDS[reDIRECT,ProfileDefault]:AFTER[KerbalismDefault]
+{
+	!MODULE[Configure] {}
+
+	RESOURCE
+	{
+		name = Oxygen
+		amount = 17000
+		maxAmount = 17000
+	}
+	RESOURCE
+	{
+		name = Nitrogen
+		amount = 2000
+		maxAmount = 2000
+	}
+	RESOURCE
+	{
+		name = Food
+		amount = 143
+		maxAmount = 143
+	}
+	RESOURCE
+	{
+		name = Water
+		amount = 55
+		maxAmount = 55
+	}
+	RESOURCE
+	{
+		name = Waste
+		amount = 0
+		maxAmount = 143
+	}
+	RESOURCE
+	{
+		name = WasteWater
+		amount = 0
+		maxAmount = 55
+	}
+}


### PR DESCRIPTION
Created this configs mainly to have realistic mission times and make resupply missions to the ISS (Habtech + Tantares) possible. Tested in JNSQ environment...

Orion: ~40 day mission capacity to allow missions towards Minmus
ATV: 5 original ATVs configured to transport supplies to ISS and remove waste
Soyuz TM/MS: Added supplies to allow ~9 day mission duration to align with real world endurance
Progress M: Configured for resupply missions to ISS to transport supplies and remove waste