### PR TITLE
Stock, Restock+, RLA probe core data

### DIFF
--- a/GameData/KerbalismConfig/Support/RLAStockalikeContinued_Science.cfg
+++ b/GameData/KerbalismConfig/Support/RLAStockalikeContinued_Science.cfg
@@ -1,0 +1,62 @@
+@PART[RLA_small_probe_4sides]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = 50
+		@sampleCapacity = 0
+	}
+}
+
+@PART[RLA_small_probe_24sides]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = 160
+		@sampleCapacity = 0
+	}
+}
+
+@PART[RLA_small_probe_6sides_gold]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = 967
+		@sampleCapacity = 0
+	}
+}
+
+@PART[RLA_small_probe_24sides_gold]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = 1130
+		@sampleCapacity = 0
+	}
+}
+
+@PART[RLA_small_probe_4sides_gold]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = 290
+		@sampleCapacity = 0
+	}
+}
+
+@PART[RLA_small_probe_8sides_gold]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = 160
+		@sampleCapacity = 0
+	}
+}
+
+@PART[RLA_small_probe_QBE_gold]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = 170
+		@sampleCapacity = 0
+	}
+}

--- a/GameData/KerbalismConfig/Support/RLAStockalikeContinued_Science.cfg
+++ b/GameData/KerbalismConfig/Support/RLAStockalikeContinued_Science.cfg
@@ -1,4 +1,4 @@
-@PART[RLA_small_probe_4sides]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[RLA_small_probe_4sides]:NEEDS[RLA_Reborn,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -7,7 +7,7 @@
 	}
 }
 
-@PART[RLA_small_probe_24sides]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[RLA_small_probe_24sides]:NEEDS[RLA_Reborn,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -16,7 +16,7 @@
 	}
 }
 
-@PART[RLA_small_probe_6sides_gold]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[RLA_small_probe_6sides_gold]:NEEDS[RLA_Reborn,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -25,7 +25,7 @@
 	}
 }
 
-@PART[RLA_small_probe_24sides_gold]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[RLA_small_probe_24sides_gold]:NEEDS[RLA_Reborn,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -34,7 +34,7 @@
 	}
 }
 
-@PART[RLA_small_probe_4sides_gold]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[RLA_small_probe_4sides_gold]:NEEDS[RLA_Reborn,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -43,7 +43,7 @@
 	}
 }
 
-@PART[RLA_small_probe_8sides_gold]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[RLA_small_probe_8sides_gold]:NEEDS[RLA_Reborn,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -52,7 +52,7 @@
 	}
 }
 
-@PART[RLA_small_probe_QBE_gold]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[RLA_small_probe_QBE_gold]:NEEDS[RLA_Reborn,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{

--- a/GameData/KerbalismConfig/Support/ReStockPlus_Science.cfg
+++ b/GameData/KerbalismConfig/Support/ReStockPlus_Science.cfg
@@ -82,5 +82,20 @@
 	}
 }
 
+@PART[restock-drone-core-0625-1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = 160
+		@sampleCapacity = 0
+	}
+}
 
-
+@PART[restock-drone-core-1875-1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = 1385
+		@sampleCapacity = 0
+	}
+}

--- a/GameData/KerbalismConfig/Support/ReStockPlus_Science.cfg
+++ b/GameData/KerbalismConfig/Support/ReStockPlus_Science.cfg
@@ -82,7 +82,7 @@
 	}
 }
 
-@PART[restock-drone-core-0625-1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[restock-drone-core-0625-1]:NEEDS[RestockPlus,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -91,7 +91,7 @@
 	}
 }
 
-@PART[restock-drone-core-1875-1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[restock-drone-core-1875-1]:NEEDS[RestockPlus,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{

--- a/GameData/KerbalismConfig/Support/SSPX.cfg
+++ b/GameData/KerbalismConfig/Support/SSPX.cfg
@@ -548,7 +548,7 @@
 	@tags ^= :$: comfort:
 }
 
-@PART[sspx-habitation-375-1|sspx-habitation-375-2|sspx-habitation-375-3]:NEEDS[StationPartsExpansionRedux,FeatureComfort]:AFTER[KerbalismDefault]
+@PART[sspx-habitation-1875-1|sspx-habitation-1875-2|sspx-habitation-375-1|sspx-habitation-375-2|sspx-habitation-375-3]:NEEDS[StationPartsExpansionRedux,FeatureComfort]:AFTER[KerbalismDefault]
 {
 	MODULE:NEEDS[FeatureComfort]
 	{
@@ -626,7 +626,7 @@
 // added by Gordon Dry
 // ============================================================================
 
-@PART[sspx-habitation-125-1]:NEEDS[StationPartsExpansionRedux,FeatureHabitat,FeatureRadiation]:AFTER[zzzKerbalismDefault]
+@PART[sspx-habitation-125-1|sspx-habitation-1875-1|sspx-habitation-1875-2]:NEEDS[StationPartsExpansionRedux,FeatureHabitat,FeatureRadiation]:AFTER[zzzKerbalismDefault]
 {
 	MODULE {
 		name = Sickbay
@@ -648,7 +648,7 @@
 // ============================================================================
 // region Recyclers
 // ============================================================================
-@PART[sspx-utility-125-1]:NEEDS[StationPartsExpansionRedux,ProfileDefault,FeatureRadiation]:AFTER[zzzKerbalismDefault]
+@PART[sspx-utility-125-1|SSPX_sspx-utility-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileDefault,FeatureRadiation]:AFTER[zzzKerbalismDefault]
 {
 	// since this part contains an active shield, it needs a big NERF:
 	// available only together with kerbalisms active shield
@@ -667,7 +667,7 @@
 	}
 }
 
-@PART[sspx-utility-125-1]:NEEDS[StationPartsExpansionRedux,ProfileDefault,FeatureReliability]:AFTER[zzzKerbalismDefault]
+@PART[sspx-utility-125-1|SSPX_sspx-utility-1875-1]:NEEDS[StationPartsExpansionRedux,ProfileDefault,FeatureReliability]:AFTER[zzzKerbalismDefault]
 {
 	MODULE
 	{

--- a/GameData/KerbalismConfig/Support/SSPX.cfg
+++ b/GameData/KerbalismConfig/Support/SSPX.cfg
@@ -536,7 +536,7 @@
 // ============================================================================
 // region Comfort providers
 // ============================================================================
-@PART[sspx-observation-25-1|sspx-cupola-125-1|sspx-cupola-375-1]:NEEDS[StationPartsExpansionRedux,FeatureComfort]:AFTER[KerbalismDefault]
+@PART[sspx-observation-25-1|sspx-cupola-125-1|sspx-cupola-1875-1|sspx-cupola-375-1]:NEEDS[StationPartsExpansionRedux,FeatureComfort]:AFTER[KerbalismDefault]
 {
 	MODULE:NEEDS[FeatureComfort]
 	{

--- a/GameData/KerbalismConfig/System/ScienceRework/Patches-HardDrives.cfg
+++ b/GameData/KerbalismConfig/System/ScienceRework/Patches-HardDrives.cfg
@@ -282,6 +282,24 @@
 	}
 }
 
+@PART[MpoProbe]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = 5643		//damn these parts are OP
+		@sampleCapacity = 0
+	}
+}
+
+@PART[MtmStage]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = 4085		//damn these parts are OP
+		@sampleCapacity = 0
+	}
+}
+
 // ============================================================================
 // Remove the ability for probe cores to store samples.
 // ============================================================================

--- a/GameData/KerbalismConfig/System/ScienceRework/Tweakables/StockHardDrives.cfg
+++ b/GameData/KerbalismConfig/System/ScienceRework/Tweakables/StockHardDrives.cfg
@@ -15,10 +15,13 @@
 // Patching mods that add a ton of command modules is a nightmare.
 // General balancing idea: based on unlock tiers. Probes get on average
 // 1.5 - 2 times more data storage due to lack of sample storage.
+// Probe numbers based on subtracting the mass attributable to gyros and
+// batteries, then multiplying the remaining mass by the cost and a constant
+// related to the tech tier. 
+//
+//
 // ============================================================================
 // Capacity Upgrades are multipliers for the base value
-
-
 // ============================================================================
 // MAKE SURE NO FIELDS ARE LEFT EMPTY OR COMMENTED OUT IN THIS SECTION,
 // OTHERWISE MODULE MANAGER WILL THROW ERRORS
@@ -79,7 +82,7 @@
 
 		Stayputnik										//T3
 		{
-			data = 1.75
+			data = 1.86
 			samples = 0
 		}
 
@@ -115,7 +118,7 @@
 
 		OKTO											//T4
 		{
-			data = 16.25
+			data = 16.28
 			samples = 0
 		}
 
@@ -151,7 +154,7 @@
 
 		HECS											//T5
 		{
-			data = 45
+			data = 46.07
 			samples = 0
 		}
 
@@ -169,20 +172,20 @@
 
 		OKTO2											//T6
 		{
-			data = 140								//much smaller than the Base Okto, but more advanced tech.
+			data = 58.83
 			samples = 0
 		}
 
 		QBE												//T6
 		{
-			data = 82.15								// really small probe core.
+			data = 25.11								// really small probe core, but cheap
 			samples = 0
 		}
 
 		RoveMate										//T6
 		{
-			data = 118.51
-			samples = 6									//only probe that can store samples?
+			data = 115.2
+			samples = 6									//only probe that can store samples
 		}
 
 		MK2DroneCore									//T7
@@ -193,25 +196,25 @@
 
 		HECS2											//T7
 		{
-			data = 738.57
+			data = 750									//this part is OP
 			samples = 0
 		}
 
 		RC-001S											//T7
 		{
-			data = 518.52
+			data = 424.13
 			samples = 0
 		}
 
 		RC-L01											//T8
 		{
-			data = 1024								//best probe in the game. it better store a crapton of data.
+			data = 3287.80								//best probe in the game. it better store a crapton of data.
 			samples = 0
 		}
 
 		RC-XL001 // restock+
 		{
-			data = 1024
+			data = 6880									//This is a lot of data
 			samples = 0
 		}
 


### PR DESCRIPTION
Probe numbers based on subtracting the mass attributable to gyros and batteries, then multiplying the remaining mass by the cost and a constant related to the tech tier. Big difference is providing non-basic hard drives for some very high-end probe cores.