### PR TITLE
new Support/Bluedog.cfg to work with apollo-saturn-revamp

### DIFF
--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -603,7 +603,7 @@
 	}
 }
 
-@PART[bluedog_Apollo_Block2_ServiceModule]:NEEDS[Bluedog_DB,FeatureHabitat]:AFTER[KerbalismDefault]
+@PART[bluedog_Apollo_Block2_ServiceModule]:HAS[!MODULE[ProcessController]:HAS[#resource[_MonopropFuelCell]]]:NEEDS[Bluedog_DB,FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	RESOURCE
 	{
@@ -650,6 +650,56 @@
 		}
 	}
 
+	!MODULE[ModuleResourceConverter]:HAS[#ConverterName[Fuel?Cell]] { }
+	!MODULE[Reliability]:HAS[#type[ModuleResourceConverter]]:NEEDS[FeatureReliability] { }
+}
+
+@PART[bluedog_Apollo_Block2_ServiceModule]:HAS[@MODULE[ProcessController]:HAS[#resource[_MonopropFuelCell]],@MODULE[Configure]:HAS[#title[?uel??ell]]]:NEEDS[Bluedog_DB,FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	RESOURCE
+	{
+		name = Water
+		amount = 0
+		maxAmount = 23.45
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _FuelCell
+		title = Fuel Cell
+		capacity = 4
+		running = false
+	}
+
+	@MODULE[Configure]:HAS[#title[?uel??ell]]
+	{
+		@slots += 1
+
+		SETUP
+		{
+			name = Hydrogen Oxygen Fuel Cell
+			desc = Burns <b>Hydrogen</b> gas and <b>Oxygen</b> gas, producing <b>Water</b> as a by-product.
+			tech = advElectrics
+			mass = 0.05
+			cost = 2500
+			valve_i = 1
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _FuelCell
+			}
+		}
+	}
+
+	!MODULE[ModuleResourceConverter]:HAS[#ConverterName[Fuel?Cell]] { }
+	!MODULE[Reliability]:HAS[#type[ModuleResourceConverter]]:NEEDS[FeatureReliability] { }
+}
+
+@PART[bluedog_Apollo_Block2_ServiceModule]:HAS[@MODULE[ProcessController]:HAS[#resource[_MonopropFuelCell]]]:NEEDS[Bluedog_DB,FeatureHabitat]:AFTER[KerbalismDefault]
+{
 	MODULE:NEEDS[FeatureReliability]
 	{
 		name = Reliability
@@ -661,8 +711,6 @@
 		extra_cost = 0.1
 		extra_mass = 0.05
 	}
-	!MODULE[ModuleResourceConverter]:HAS[#ConverterName[Fuel?Cell]] { }
-	!MODULE[Reliability]:HAS[#type[ModuleResourceConverter]]:NEEDS[FeatureReliability] { }
 }
 
 @PART[bluedog_LM_Ascent_Cockpit]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]]:NEEDS[Bluedog_DB,FeatureHabitat]:FOR[KerbalismDefault]

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -179,6 +179,17 @@
 	}
 }
 
+@PART[bluedog_LM_Ascent_Cockpit]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]]:NEEDS[FeatureHabitat]:FOR[KerbalismDefault]
+{
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]
+	{
+		@SUBTYPE[MonoProp]
+		{
+			%volumeAdded = 26.666666
+			%tankType = bdbSupplyOxygen
+		}
+	}
+}
 
 @PART[bluedog_Corona_Pod]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -179,18 +179,6 @@
 	}
 }
 
-@PART[bluedog_LM_Ascent_Cockpit]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]]:NEEDS[FeatureHabitat]:FOR[KerbalismDefault]
-{
-	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]
-	{
-		@SUBTYPE[MonoProp]
-		{
-			%volumeAdded = 26.666666
-			%tankType = bdbSupplyOxygen
-		}
-	}
-}
-
 @PART[bluedog_Corona_Pod]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
@@ -594,6 +582,42 @@
 	{
 		%volume = 12.2
 		%surface = 26.4
+	}
+}
+
+// ============================================================================
+// Parts with fuelCellSwitch
+// by GordonDry
+// GameData\Bluedog_DB_Extras\Fuel Cell\CRP fuel cells.cfg
+// ============================================================================
+
+
+@PART[bluedog_Apollo_Block2_SM]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]]:NEEDS[FeatureHabitat]:FOR[KerbalismDefault]
+{
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]
+	{
+		@SUBTYPE[MonoProp]
+		{
+			%volumeAdded = 0.958974
+			%tankType = bdbSupplyOxygen
+		}
+	}
+}
+
+@PART[bluedog_LM_Ascent_Cockpit]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]]:NEEDS[FeatureHabitat]:FOR[KerbalismDefault]
+{
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]
+	{
+		@SUBTYPE[None]
+		{
+			%volumeAdded = 0.479487
+			%tankType = bdbSupplyOxygen
+		}
+		@SUBTYPE[MonoProp]
+		{
+			%volumeAdded = 0.479487
+			%tankType = bdbSupplyOxygen
+		}
 	}
 }
 

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -610,8 +610,7 @@
 		name = ProcessController
 		resource = _FuelCell
 		title = Fuel Cell
-		capacity = 25
-		@capacity *= 1.67
+		capacity = 4
 		running = false
 	}
 
@@ -636,6 +635,11 @@
 				id_field = resource
 				id_value = _FuelCell
 			}
+		}
+		SETUP
+		{
+		  name = None
+		  desc = #KERBALISM_None_desc//Empty slot for mass and cost savings.
 		}
 	}
 

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -2894,15 +2894,15 @@
 
 @PART[bluedog_GATV_MaterialsBay]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
 {
-	MODULE
+	%MODULE[HardDrive]
 	{
-		name = HardDrive
-		experiment_id = mobileMaterialsLab
-		dataCapacity = 0
-		sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/PRIVATE_DRIVES/bluedog_GATV_MaterialsBay/samples$
+		%experiment_id = mobileMaterialsLab
+		%dataCapacity = 0
+		%sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/PRIVATE_DRIVES/bluedog_GATV_MaterialsBay/samples$
 
-		UPGRADES
+		%UPGRADES
 		{
+			-UPGRADE:HAS[#name__[MatBay-Storage-Upgrade]]
 			UPGRADE
 			{
 				name__ = MatBay-Storage-Upgrade

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -828,7 +828,6 @@
 
 	@MODULE[ProcessController]:HAS[#resource[_MonopropFuelCell]]
 	{
-		%capacity = #$/CrewCapacity$
 		@capacity *= 5
 	    %valve_i = 2
 		%running = false
@@ -841,6 +840,7 @@
 		title = Fuel Cell
 		capacity = #$/CrewCapacity$
 		@capacity *= 5
+		@capacity *= 1.67
 	    valve_i = 1
 		running = false
 	}
@@ -863,7 +863,11 @@
 
 		%SETUP:HAS[#name[Monoprop?Oxygen?Fuel?Cell]]
 		{
+			%name = Monoprop Oxygen Fuel Cell
+			%desc = #KERBALISM_MonopropO2FuelCell_desc//An emergency fuel cell that burns <b>MonoPropellant</b> and <b>Oxygen</b> gas, producing <b>Water</b> and <b>Nitrogen</b> gas as by-products.
 			%tech = survivability
+			%mass = 0.1
+			%cost = 1000
 		}
 
 		SETUP

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -1375,7 +1375,7 @@
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_camera],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_camera],~name[Experiment]]/xmitDataScalar$
-		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_camera],~name[Experiment]]/animationName$
     }
 
     !MODULE:HAS[#experimentID[bd_camera],~name[Experiment]] {}
@@ -1446,7 +1446,7 @@
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_gammaRay],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_gammaRay/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_gammaRay],~name[Experiment]]/xmitDataScalar$
-		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_gammaRay],~name[Experiment]]/animationName$
 		allow_shrouded = False
 	}
 
@@ -1579,7 +1579,7 @@
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_ionElec/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_ionElec],~name[Experiment]]/xmitDataScalar$
 		allow_shrouded = False
-		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_ionElec],~name[Experiment]]/animationName$
 	}
 
 	!MODULE:HAS[#experimentID[bd_ionElec],~name[Experiment]] {}
@@ -1638,7 +1638,7 @@
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_IRradiometer],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRradiometer/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_IRradiometer],~name[Experiment]]/xmitDataScalar$
-		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_IRradiometer],~name[Experiment]]/animationName$
 		allow_shrouded = False
     }
 
@@ -1714,7 +1714,7 @@
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_IRspec],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_IRspec],~name[Experiment]]/xmitDataScalar$
-		anim_deploy = #$../MODULE:HAS[#animationName,~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#animationName[bd_IRspec],~name[Experiment]]/animationName$
 		allow_shrouded = False
     }
 
@@ -1804,7 +1804,7 @@
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_magScan],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_magScan/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_magScan],~name[Experiment]]/xmitDataScalar$
-		anim_deploy = #$../MODULE:HAS[#animationName,~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#animationName[bd_magScan],~name[Experiment]]/animationName$
 		allow_shrouded = False
 	}
 
@@ -1875,7 +1875,7 @@
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_mapping/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_mapping],~name[Experiment]]/xmitDataScalar$
 		allow_shrouded = False
-		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_mapping],~name[Experiment]]/animationName$
 		sample_amount = 2
 		requirements = SunAngleMax:55
 	}
@@ -1931,7 +1931,7 @@
 		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/size$
 		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/duration$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/ec_rate$
-		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_massSpec],~name[Experiment]]/animationName$
 	}
 
     !MODULE:HAS[#experimentID[bd_massSpec],~name[Experiment]] {}
@@ -2041,7 +2041,7 @@
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_orbitalScope],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_orbitalScope/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_orbitalScope],~name[Experiment]]/xmitDataScalar$
-		anim_deploy = #$../MODULE:HAS[#experimentActionName,~name[Experiment]]/experimentActionName$
+		anim_deploy = #$../MODULE:HAS[#experimentActionName[bd_orbitalScope],~name[Experiment]]/experimentActionName$
 		allow_shrouded = False
 		requirements = SunAngleMax:55
     }
@@ -2109,7 +2109,7 @@
 		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/size$
 		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/duration$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/ec_rate$
-		anim_deploy = #$../MODULE:HAS[#animationName,~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#animationName[bd_oso],~name[Experiment]]/animationName$
 		allow_shrouded = False
 		restriction = Sunlight
     }
@@ -2210,7 +2210,7 @@
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_radarAltimeter],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_radarAltimeter/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_radarAltimeter],~name[Experiment]]/xmitDataScalar$
-		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_radarAltimeter],~name[Experiment]]/animationName$
 	}
 
     !MODULE:HAS[#experimentID[bd_radarAltimeter],~name[Experiment]] {}
@@ -2265,7 +2265,7 @@
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_rpws/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_rpws],~name[Experiment]]/xmitDataScalar$
 		allow_shrouded = False
-		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/experimentActionName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_rpws],~name[Experiment]]/experimentActionName$
 	}
 
     !MODULE:HAS[#experimentID[bd_rpws],~name[Experiment]] {}
@@ -2362,7 +2362,7 @@
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_solarWind],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_solarWind/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_solarWind],~name[Experiment]]/xmitDataScalar$
-		anim_deploy = #$../MODULE:HAS[#animationName,~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#animationName[bd_solarWind],~name[Experiment]]/animationName$
 		restriction = Sunlight
 	}
 
@@ -2414,7 +2414,7 @@
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_surveillance/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_surveillance],~name[Experiment]]/xmitDataScalar$
 		allow_shrouded = False
-		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_surveillance],~name[Experiment]]/animationName$
 	}
 
     !MODULE:HAS[#experimentID[bd_surveillance],~name[Experiment]] {}
@@ -2455,7 +2455,7 @@
 		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_TVcamera/duration$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_TVcamera/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_TVcamera],~name[Experiment]]/xmitDataScalar$
-		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_TVcamera],~name[Experiment]]/animationName$
 		allow_shrouded = false
     }
 
@@ -2513,7 +2513,7 @@
 		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVscope/duration$
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_UVscope],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVscope/ec_rate$
-		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_UVscope],~name[Experiment]]/animationName$
 		allow_shrouded = false
     }
 
@@ -2573,7 +2573,7 @@
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_UVspec],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVspec/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_UVspec],~name[Experiment]]/xmitDataScalar$
-		anim_deploy = #$../MODULE:HAS[#animationName,~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#animationName[bd_UVspec],~name[Experiment]]/animationName$
 		allow_shrouded = false
 	}
 
@@ -2671,7 +2671,7 @@
 		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_XrayImaging/duration$
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_XrayImaging],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_XrayImaging/ec_rate$
-		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_XrayImaging],~name[Experiment]]/animationName$
 	}
 
     !MODULE:HAS[#experimentID[bd_XrayImaging],~name[Experiment]] {}

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -1285,7 +1285,7 @@
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_bioexp],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_bioexp/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_bioexp],~name[Experiment]]/xmitDataScalar$
-		@anim_deploy:HAS[@MODULE[*Module*]:HAS[#animationName]] = #$../MODULE:HAS[#animationName],~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_bioexp]],~name[Experiment]]/experimentActionName$
     }
 
     !MODULE:HAS[#experimentID[bd_bioexp],~name[Experiment]] {}
@@ -2152,7 +2152,7 @@
 		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_Photometer/duration$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_Photometer/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_Photometer],~name[Experiment]]/xmitDataScalar$
-		@anim_deploy:HAS[@MODULE[*ModuleScience*]:HAS[#animationName,#experimentID[bd_Photometer]]] = #$../MODULE:HAS[#experimentID[bd_Photometer],~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_Photometer],~name[Experiment]]/experimentActionName$
 		allow_shrouded = False
 	}
 

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -110,7 +110,7 @@
 	}
 }
 
-@PART[bluedog_MiniLab_Lab,bluedog_MOL_1p5mStationSegment,bluedog_MOL_Camera]:HAS[!MODULE[HardDrive]]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_MiniLab_Lab,bluedog_MOL_1p5mStationSegment,bluedog_MOL_Camera]:HAS[!MODULE[HardDrive]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	MODULE
 	{
@@ -121,7 +121,7 @@
 	}
 }
 
-@PART[bluedog_Skylab_Workshop,bluedog_Skylab_WetWorkshop]:HAS[!MODULE[HardDrive]]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Skylab_Workshop,bluedog_Skylab_WetWorkshop]:HAS[!MODULE[HardDrive]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	MODULE
 	{
@@ -132,7 +132,7 @@
 	}
 }
 
-@PART[bluedog_MOL_Lab_New,bluedog_spacelab_europeanModule]:HAS[!MODULE[HardDrive]]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_MOL_Lab_New,bluedog_spacelab_europeanModule]:HAS[!MODULE[HardDrive]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	MODULE
 	{
@@ -143,7 +143,7 @@
 	}
 }
 
-@PART[bluedog_Gemini_Capsule,bluedog_Gemini_LanderCan]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Gemini_Capsule,bluedog_Gemini_LanderCan]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -152,7 +152,7 @@
 	}
 }
 
-@PART[bluedog_Apollo_CrewPod,X20Cockpit,X20Cockpit2]:NEEDS[FeatureScience]:FOR[zKerbalismDefault]
+@PART[bluedog_Apollo_CrewPod,X20Cockpit,X20Cockpit2]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zKerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -161,7 +161,7 @@
 	}
 }
 
-@PART[bluedog_Apollo_Block3_Capsule]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Apollo_Block3_Capsule]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -170,7 +170,7 @@
 	}
 }
 
-@PART[bluedog_LM_Ascent_Cockpit]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_LM_Ascent_Cockpit]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -179,7 +179,7 @@
 	}
 }
 
-@PART[bluedog_Corona_Pod]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Corona_Pod]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -188,7 +188,7 @@
 	}
 }
 
-@PART[bluedog_Hexagon_Mk8_Capsule]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Hexagon_Mk8_Capsule]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -199,7 +199,7 @@
 }
 
 
-@PART[bluedog_Telstar_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Telstar_Core]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -208,7 +208,7 @@
 	}
 }
 
-@PART[bluedog_Courier_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Courier_Core]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -217,7 +217,7 @@
 	}
 }
 
-@PART[bluedog_Relay_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Relay_Core]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -226,7 +226,7 @@
 	}
 }
 
-@PART[bluedog_AIMP_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_AIMP_Core]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -235,7 +235,7 @@
 	}
 }
 
-@PART[bluedog_Alouette_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Alouette_Core]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -244,7 +244,7 @@
 	}
 }
 
-@PART[bluedog_Biosat_Adapter]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Biosat_Adapter]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -253,7 +253,7 @@
 	}
 }
 
-@PART[bluedog_Helios_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Helios_Core]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -262,7 +262,7 @@
 	}
 }
 
-@PART[bluedog_IDCSP_Probe]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_IDCSP_Probe]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -271,7 +271,7 @@
 	}
 }
 
-@PART[bluedog_Pioneer_1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Pioneer_1]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -280,7 +280,7 @@
 	}
 }
 
-@PART[bluedog_Pioneer_4]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Pioneer_4]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -289,7 +289,7 @@
 	}
 }
 
-@PART[bluedog_Pioneer5_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Pioneer5_Core]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -298,7 +298,7 @@
 	}
 }
 
-@PART[bluedog_Explorer_7]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Explorer_7]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -307,7 +307,7 @@
 	}
 }
 
-@PART[bluedog_Explorer_8]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Explorer_8]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -316,7 +316,7 @@
 	}
 }
 
-@PART[bluedog_Explorer_11]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Explorer_11]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -325,7 +325,7 @@
 	}
 }
 
-@PART[bluedog_Explorer_S45]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Explorer_S45]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -334,7 +334,7 @@
 	}
 }
 
-@PART[bluedog_Explorer_S46]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Explorer_S46]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -343,7 +343,7 @@
 	}
 }
 
-@PART[bluedog_LunarOrbiter_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_LunarOrbiter_Core]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -352,7 +352,7 @@
 	}
 }
 
-@PART[bluedog_Nimbus_EarlyControlCore]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Nimbus_EarlyControlCore]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -361,7 +361,7 @@
 	}
 }
 
-@PART[bluedog_Nimbus_LateControlCore]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Nimbus_LateControlCore]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -371,7 +371,7 @@
 }
 
 
-@PART[bluedog_OAO_ProbeCore]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_OAO_ProbeCore]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -380,7 +380,7 @@
 	}
 }
 
-@PART[bluedog_Mariner10_probeCore]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Mariner10_probeCore]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -390,7 +390,7 @@
 }
 
 
-@PART[bluedog_OGO_Bus]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_OGO_Bus]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -399,7 +399,7 @@
 	}
 }
 
-@PART[bluedog_OSO_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_OSO_Core]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -408,7 +408,7 @@
 	}
 }
 
-@PART[bluedog_Pioneer6_Bus]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Pioneer6_Bus]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -417,7 +417,7 @@
 	}
 }
 
-@PART[bluedog_PioneerAble_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_PioneerAble_Core]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -426,7 +426,7 @@
 	}
 }
 
-@PART[bluedog_MarinerB_Bus]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_MarinerB_Bus]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -435,7 +435,7 @@
 	}
 }
 
-@PART[bluedog_Ranger_Bus]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Ranger_Bus]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -444,7 +444,7 @@
 	}
 }
 
-@PART[bluedog_Ranger_BareCore]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Ranger_BareCore]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -453,7 +453,7 @@
 	}
 }
 
-@PART[bluedog_TIROS]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_TIROS]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -462,7 +462,7 @@
 	}
 }
 
-@PART[bluedog_TRYP_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_TRYP_Core]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -471,7 +471,7 @@
 	}
 }
 
-@PART[bluedog_Transit4A]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Transit4A]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -480,7 +480,7 @@
 	}
 }
 
-@PART[bluedog_Transit5_Bus]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Transit5_Bus]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -489,7 +489,7 @@
 	}
 }
 
-@PART[bluedog_ANNA]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_ANNA]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -498,7 +498,7 @@
 	}
 }
 
-@PART[bluedog_Injun1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Injun1]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -507,7 +507,7 @@
 	}
 }
 
-@PART[bluedog_LOFTI]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_LOFTI]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -516,7 +516,7 @@
 	}
 }
 
-@PART[bluedog_POPPY1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_POPPY1]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -525,7 +525,7 @@
 	}
 }
 
-@PART[bluedog_POPPY2]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_POPPY2]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -534,7 +534,7 @@
 	}
 }
 
-@PART[bluedog_SOLRAD]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_SOLRAD]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -543,7 +543,7 @@
 	}
 }
 
-@PART[bluedog_SOLRAD8]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_SOLRAD8]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -552,7 +552,7 @@
 	}
 }
 
-@PART[bluedog_Transit2A]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+@PART[bluedog_Transit2A]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
 	@MODULE[HardDrive]
 	{
@@ -591,7 +591,7 @@
 // GameData\Bluedog_DB_Extras\Fuel Cell\CRP fuel cells.cfg
 // ============================================================================
 
-@PART[bluedog_Apollo_Block2_SM]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]]:NEEDS[FeatureHabitat]:FOR[KerbalismDefault]
+@PART[bluedog_Apollo_Block2_SM]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]]:NEEDS[Bluedog_DB,FeatureHabitat]:FOR[KerbalismDefault]
 {
 	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]
 	{
@@ -603,7 +603,7 @@
 	}
 }
 
-@PART[bluedog_Apollo_Block2_ServiceModule]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]]:NEEDS[FeatureHabitat]:FOR[KerbalismDefault]
+@PART[bluedog_Apollo_Block2_ServiceModule]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]]:NEEDS[Bluedog_DB,FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	MODULE
 	{
@@ -654,7 +654,7 @@
 	!MODULE[Reliability]:HAS[#type[ModuleResourceConverter]]:NEEDS[FeatureReliability] { }
 }
 
-@PART[bluedog_LM_Ascent_Cockpit]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]]:NEEDS[FeatureHabitat]:FOR[KerbalismDefault]
+@PART[bluedog_LM_Ascent_Cockpit]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]]:NEEDS[Bluedog_DB,FeatureHabitat]:FOR[KerbalismDefault]
 {
 	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]
 	{
@@ -1230,7 +1230,7 @@
 
 // More parts now have Geigercounters, time for a catch-all patch
 
-@PART[*]:HAS[@MODULE:HAS[#experimentID[bd_GeigerCounter]]]:NEEDS[FeatureScience]
+@PART[*]:HAS[@MODULE:HAS[#experimentID[bd_GeigerCounter]]]:NEEDS[Bluedog_DB,FeatureScience]
 {
 	!MODULE:HAS[#experimentID[bd_GeigerCounter]]	{}
 	{

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -698,9 +698,9 @@
 	!MODULE[Reliability]:HAS[#type[ModuleResourceConverter]]:NEEDS[FeatureReliability] { }
 }
 
-@PART[bluedog_Apollo_Block2_ServiceModule]:HAS[@MODULE[ProcessController]:HAS[#resource[_MonopropFuelCell]]]:NEEDS[Bluedog_DB,FeatureHabitat]:AFTER[KerbalismDefault]
+@PART[bluedog_Apollo_Block2_ServiceModule]:HAS[@MODULE[ProcessController]:HAS[#resource[_MonopropFuelCell]],!MODULE[Reliability]:HAS[#title[?uel??ell]]]:NEEDS[Bluedog_DB,FeatureHabitat,FeatureReliability]:AFTER[KerbalismDefault]
 {
-	MODULE:NEEDS[FeatureReliability]
+	MODULE
 	{
 		name = Reliability
 		type = ProcessController

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -861,7 +861,7 @@
 			}
 		}
 
-		%SETUP:HAS{#name[Monoprop?Oxygen?Fuel?Cell]]
+		%SETUP:HAS[#name[Monoprop?Oxygen?Fuel?Cell]]
 		{
 			%tech = survivability
 		}

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -1375,7 +1375,7 @@
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_camera],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_camera],~name[Experiment]]/xmitDataScalar$
-		anim_deploy = #$../MODULE:HAS[#experimentID[bd_camera],~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_camera],~name[Experiment]]/experimentActionName$
     }
 
     !MODULE:HAS[#experimentID[bd_camera],~name[Experiment]] {}
@@ -1714,7 +1714,7 @@
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_IRspec],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_IRspec],~name[Experiment]]/xmitDataScalar$
-		anim_deploy = #$../MODULE:HAS[#animationName[bd_IRspec],~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#animationName[bd_IRspec],~name[Experiment]]/experimentActionName$
 		allow_shrouded = False
     }
 
@@ -1804,7 +1804,7 @@
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_magScan],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_magScan/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_magScan],~name[Experiment]]/xmitDataScalar$
-		anim_deploy = #$../MODULE:HAS[#animationName[bd_magScan],~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#animationName[bd_magScan],~name[Experiment]]/experimentActionName$
 		allow_shrouded = False
 	}
 
@@ -1931,7 +1931,7 @@
 		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/size$
 		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/duration$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/ec_rate$
-		anim_deploy = #$../MODULE:HAS[#experimentID[bd_massSpec],~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_massSpec],~name[Experiment]]/experimentActionName$
 	}
 
     !MODULE:HAS[#experimentID[bd_massSpec],~name[Experiment]] {}
@@ -2041,7 +2041,7 @@
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_orbitalScope],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_orbitalScope/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_orbitalScope],~name[Experiment]]/xmitDataScalar$
-		anim_deploy = #$../MODULE:HAS[#experimentActionName[bd_orbitalScope],~name[Experiment]]/experimentActionName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_orbitalScope],~name[Experiment]]/experimentActionName$
 		allow_shrouded = False
 		requirements = SunAngleMax:55
     }
@@ -2109,7 +2109,7 @@
 		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/size$
 		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/duration$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/ec_rate$
-		anim_deploy = #$../MODULE:HAS[#animationName[bd_oso],~name[Experiment]]/animationName$
+		anim_deploy = #$../MODULE:HAS[#animationName[bd_oso],~name[Experiment]]/experimentActionName$
 		allow_shrouded = False
 		restriction = Sunlight
     }

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -822,19 +822,16 @@
 // added by Gordon Dry
 // ============================================================================
 
-@PART[bluedog_Spacelab_ERM]:NEEDS[HabTech2,ProfileDefault]:FOR[KerbalismDefault]
+@PART[bluedog_Spacelab_ERM]:NEEDS[HabTech2,ProfileDefault]:AFTER[KerbalismDefault]
 {
 	@tags ^= :$: fuel cell fuelcell water recycler waste processor anthraquinone soe: 
 
-	MODULE
+	@MODULE[ProcessController]:HAS[#resource[_MonopropFuelCell]]
 	{
-		name = ProcessController
-		resource = _MonopropFuelCell
-		title = Fuel cell
-		capacity = #$/CrewCapacity$
+		%capacity = #$/CrewCapacity$
 		@capacity *= 5
-	    valve_i = 2
-		running = false
+	    %valve_i = 2
+		%running = false
 	}
 
 	MODULE
@@ -843,6 +840,7 @@
 		resource = _FuelCell
 		title = Fuel Cell
 		capacity = #$/CrewCapacity$
+		@capacity *= 5
 	    valve_i = 1
 		running = false
 	}
@@ -863,20 +861,9 @@
 			}
 		}
 
-		SETUP
+		%SETUP:HAS{#name[Monoprop?Oxygen?Fuel?Cell]]
 		{
-			name = Monoprop Oxygen Fuel Cell
-			desc = Burns <b>MonoPropellant</b> and <b>Oxygen</b> gas, producing <b>Water</b> and <b>Nitrogen</b> gas as by-products.
-			tech = survivability
-			mass = 0.1
-			cost = 1000
-
-			MODULE
-			{
-				type = ProcessController
-				id_field = resource
-				id_value = _MonopropFuelCell
-			}
+			%tech = survivability
 		}
 
 		SETUP
@@ -3131,6 +3118,7 @@
 	
 	!MODULE[ModuleGenerator] {}
 	!MODULE[ModuleCoreHeat] {}
+	!MODULE[ModuleRadioisotopeGenerator] {}
 }
 
 @PART[bluedog_Transit5_SNAP9A]:NEEDS[Bluedog_DB,FeatureRadiation]:FOR[KerbalismDefault]
@@ -3153,6 +3141,7 @@
 	
 	!MODULE[ModuleGenerator] {}
 	!MODULE[ModuleCoreHeat] {}
+	!MODULE[ModuleRadioisotopeGenerator] {}
 }
 
 
@@ -3176,6 +3165,7 @@
 	
 	!MODULE[ModuleGenerator] {}
 	!MODULE[ModuleCoreHeat] {}
+	!MODULE[ModuleRadioisotopeGenerator] {}
 }
 
 @PART[bluedog_Transit5_RTG]:NEEDS[Bluedog_DB,FeatureRadiation]:FOR[KerbalismDefault]
@@ -3198,6 +3188,7 @@
 	
 	!MODULE[ModuleGenerator] {}
 	!MODULE[ModuleCoreHeat] {}
+	!MODULE[ModuleRadioisotopeGenerator] {}
 }
 
 @PART[bluedog_RTG_SNAP19_Nimbus]:NEEDS[Bluedog_DB,FeatureRadiation]:FOR[KerbalismDefault]
@@ -3220,6 +3211,7 @@
 	
 	!MODULE[ModuleGenerator] {}
 	!MODULE[ModuleCoreHeat] {}
+	!MODULE[ModuleRadioisotopeGenerator] {}
 }
 
 @PART[bluedog_RTG_SNAP19_Quad]:NEEDS[Bluedog_DB,FeatureRadiation]:FOR[KerbalismDefault]
@@ -3242,4 +3234,5 @@
 	
 	!MODULE[ModuleGenerator] {}
 	!MODULE[ModuleCoreHeat] {}
+	!MODULE[ModuleRadioisotopeGenerator] {}
 }

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -603,6 +603,57 @@
 	}
 }
 
+@PART[bluedog_Apollo_Block2_ServiceModule]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]]:NEEDS[FeatureHabitat]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = ProcessController
+		resource = _FuelCell
+		title = Fuel Cell
+		capacity = 25
+		@capacity *= 1.67
+		running = false
+	}
+
+	MODULE
+	{
+		name = Configure
+		title = Fuel Cell
+		slots = 1
+
+		SETUP
+		{
+			name = Hydrogen Oxygen Fuel Cell
+			desc = Burns <b>Hydrogen</b> gas and <b>Oxygen</b> gas, producing <b>Water</b> as a by-product.
+			tech = advElectrics
+			mass = 0.05
+			cost = 2500
+			valve_i = 1
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _FuelCell
+			}
+		}
+	}
+
+	MODULE:NEEDS[FeatureReliability]
+	{
+		name = Reliability
+		type = ProcessController
+		title = Fuel Cell
+		redundancy = Power Generation
+		repair = Engineer
+		mtbf = 72576000
+		extra_cost = 0.1
+		extra_mass = 0.05
+	}
+	!MODULE[ModuleResourceConverter]:HAS[#ConverterName[Fuel?Cell]] { }
+	!MODULE[Reliability]:HAS[#type[ModuleResourceConverter]]:NEEDS[FeatureReliability] { }
+}
+
 @PART[bluedog_LM_Ascent_Cockpit]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]]:NEEDS[FeatureHabitat]:FOR[KerbalismDefault]
 {
 	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -1714,7 +1714,7 @@
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_IRspec],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_IRspec],~name[Experiment]]/xmitDataScalar$
-		anim_deploy = #$../MODULE:HAS[#animationName[bd_IRspec],~name[Experiment]]/experimentActionName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_IRspec],~name[Experiment]]/experimentActionName$
 		allow_shrouded = False
     }
 
@@ -1804,7 +1804,7 @@
 		@data_rate *= #$../MODULE:HAS[#experimentID[bd_magScan],~name[Experiment]]/xmitDataScalar$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_magScan/ec_rate$
 		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_magScan],~name[Experiment]]/xmitDataScalar$
-		anim_deploy = #$../MODULE:HAS[#animationName[bd_magScan],~name[Experiment]]/experimentActionName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_magScan],~name[Experiment]]/experimentActionName$
 		allow_shrouded = False
 	}
 
@@ -2109,7 +2109,7 @@
 		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/size$
 		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/duration$
 		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/ec_rate$
-		anim_deploy = #$../MODULE:HAS[#animationName[bd_oso],~name[Experiment]]/experimentActionName$
+		anim_deploy = #$../MODULE:HAS[#experimentID[bd_oso],~name[Experiment]]/experimentActionName$
 		allow_shrouded = False
 		restriction = Sunlight
     }

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -603,7 +603,7 @@
 	}
 }
 
-@PART[bluedog_Apollo_Block2_ServiceModule]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]]:NEEDS[Bluedog_DB,FeatureHabitat]:AFTER[KerbalismDefault]
+@PART[bluedog_Apollo_Block2_ServiceModule]:NEEDS[Bluedog_DB,FeatureHabitat]:AFTER[KerbalismDefault]
 {
 	MODULE
 	{

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -674,8 +674,6 @@
 
 	@MODULE[Configure]:HAS[#title[?uel??ell]]
 	{
-		@slots += 1
-
 		SETUP
 		{
 			name = Hydrogen Oxygen Fuel Cell

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -605,6 +605,13 @@
 
 @PART[bluedog_Apollo_Block2_ServiceModule]:NEEDS[Bluedog_DB,FeatureHabitat]:AFTER[KerbalismDefault]
 {
+	RESOURCE
+	{
+		name = Water
+		amount = 0
+		maxAmount = 23.45
+	}
+
 	MODULE
 	{
 		name = ProcessController

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -1,4 +1,568 @@
 // ============================================================================
+// BDB HDD configs
+// ============================================================================
+@KERBALISM_HDD_SIZES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	BDB
+	{
+	
+		bdbtier1
+		{
+			data = 4.75
+			samples = 0
+		}
+		bdbtier2
+		{
+			data = 8.75
+			samples = 0
+		}
+		bdbtier3
+		{
+			data = 16.75
+			samples = 0
+		}
+		bdbtier4
+		{
+			data = 64.75
+			samples = 0
+		}
+		bdbtier5
+		{
+			data = 132.75
+			samples = 0
+		}
+		
+		bdbtier6
+		{
+			data = 264.75
+			samples = 0
+		}
+		bdbgemini
+		{
+			data = 16.75
+			samples = 2
+		}
+		bdbmi
+		{
+			data = 16.75
+			samples = 2
+		}
+		bdbapollo
+		{
+			data = 32.75
+			samples = 4
+		}
+		bdbapollo1
+		{
+			data = 132.75
+			samples = 8
+		}
+		bdblem
+		{
+			data = 16.75
+			samples = 2
+		}
+		bluedog_Gemini_Lab
+		{
+			data = 48.75
+			samples = 12
+		}
+		bluedog_MiniLab_Lab
+		{
+			data = 26.75
+			samples = 6
+		}
+		bluedog_Skylab_OWS
+		{
+			data = 1264.75
+			samples = 24
+		}
+		bdbtier7
+		{
+			data = 428.75
+			samples = 0
+		}		
+		bdbcamerareturn
+		{
+			data = 0
+			samples = 2
+		}
+		PRIVATE_DRIVES
+		{
+			bluedog_MiniGoo
+			{
+				data = 0
+				samples = 1
+				SampleReservoirUpgrade = 1				
+				UpgradeTech = basicScience
+				UpgradeEntryCost = 1600
+			}
+			
+			bluedog_GATV_MaterialsBay
+			{
+				data = 0
+				samples = 4							
+				SampleReservoirUpgrade = 2				
+				UpgradeTech = precisionEngineering
+				UpgradeEntryCost = 6800
+			}
+		}
+	}
+}
+
+@PART[bluedog_MiniLab_Lab,bluedog_MOL_1p5mStationSegment,bluedog_MOL_Camera]:HAS[!MODULE[HardDrive]]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = HardDrive
+		title = Laboratory Storage
+		dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bluedog_MiniLab_Lab/data$
+		sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bluedog_MiniLab_Lab/samples$
+	}
+}
+
+@PART[bluedog_Skylab_Workshop,bluedog_Skylab_WetWorkshop]:HAS[!MODULE[HardDrive]]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = HardDrive
+		title = Laboratory Storage
+		dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bluedog_Skylab_OWS/data$
+		sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bluedog_Skylab_OWS/samples$
+	}
+}
+
+@PART[bluedog_MOL_Lab_New,bluedog_spacelab_europeanModule]:HAS[!MODULE[HardDrive]]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = HardDrive
+		title = Laboratory Storage
+		dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bluedog_Gemini_Lab/data$
+		sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bluedog_Gemini_Lab/samples$
+	}
+}
+
+@PART[bluedog_Gemini_Capsule,bluedog_Gemini_LanderCan]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbgemini/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbgemini/samples$
+	}
+}
+
+@PART[bluedog_Apollo_CrewPod,X20Cockpit,X20Cockpit2]:NEEDS[FeatureScience]:FOR[zKerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbapollo/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbapollo/samples$
+	}
+}
+
+@PART[bluedog_Apollo_Block3_Capsule]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbapollo1/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbapollo1/samples$
+	}
+}
+
+@PART[bluedog_LM_Ascent_Cockpit]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdblem/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdblem/samples$
+	}
+}
+
+
+@PART[bluedog_Corona_Pod]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbcamerareturn/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbcamerareturn/samples$
+	}
+}
+
+@PART[bluedog_Hexagon_Mk8_Capsule]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbcamerareturn/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbcamerareturn/samples$
+		@sampleCapacity *= 2
+	}
+}
+
+
+@PART[bluedog_Telstar_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier1/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier1/samples$
+	}
+}
+
+@PART[bluedog_Courier_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier1/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier1/samples$
+	}
+}
+
+@PART[bluedog_Relay_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier1/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier1/samples$
+	}
+}
+
+@PART[bluedog_AIMP_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/samples$
+	}
+}
+
+@PART[bluedog_Alouette_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/samples$
+	}
+}
+
+@PART[bluedog_Biosat_Adapter]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/samples$
+	}
+}
+
+@PART[bluedog_Helios_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier5/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier5/samples$
+	}
+}
+
+@PART[bluedog_IDCSP_Probe]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier1/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier1/samples$
+	}
+}
+
+@PART[bluedog_Pioneer_1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier1/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier1/samples$
+	}
+}
+
+@PART[bluedog_Pioneer_4]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/samples$
+	}
+}
+
+@PART[bluedog_Pioneer5_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/samples$
+	}
+}
+
+@PART[bluedog_Explorer_7]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/samples$
+	}
+}
+
+@PART[bluedog_Explorer_8]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/samples$
+	}
+}
+
+@PART[bluedog_Explorer_11]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/samples$
+	}
+}
+
+@PART[bluedog_Explorer_S45]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/samples$
+	}
+}
+
+@PART[bluedog_Explorer_S46]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/samples$
+	}
+}
+
+@PART[bluedog_LunarOrbiter_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/samples$
+	}
+}
+
+@PART[bluedog_Nimbus_EarlyControlCore]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/samples$
+	}
+}
+
+@PART[bluedog_Nimbus_LateControlCore]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier4/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier4/samples$
+	}
+}
+
+
+@PART[bluedog_OAO_ProbeCore]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier5/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier5/samples$
+	}
+}
+
+@PART[bluedog_Mariner10_probeCore]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier5/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier5/samples$
+	}
+}
+
+
+@PART[bluedog_OGO_Bus]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/samples$
+	}
+}
+
+@PART[bluedog_OSO_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/samples$
+	}
+}
+
+@PART[bluedog_Pioneer6_Bus]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/samples$
+	}
+}
+
+@PART[bluedog_PioneerAble_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/samples$
+	}
+}
+
+@PART[bluedog_MarinerB_Bus]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier4/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier4/samples$
+	}
+}
+
+@PART[bluedog_Ranger_Bus]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/samples$
+	}
+}
+
+@PART[bluedog_Ranger_BareCore]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/samples$
+	}
+}
+
+@PART[bluedog_TIROS]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/samples$
+	}
+}
+
+@PART[bluedog_TRYP_Core]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier5/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier5/samples$
+	}
+}
+
+@PART[bluedog_Transit4A]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/samples$
+	}
+}
+
+@PART[bluedog_Transit5_Bus]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/samples$
+	}
+}
+
+@PART[bluedog_ANNA]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/samples$
+	}
+}
+
+@PART[bluedog_Injun1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier1/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier1/samples$
+	}
+}
+
+@PART[bluedog_LOFTI]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier1/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier1/samples$
+	}
+}
+
+@PART[bluedog_POPPY1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/samples$
+	}
+}
+
+@PART[bluedog_POPPY2]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/samples$
+	}
+}
+
+@PART[bluedog_SOLRAD]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/samples$
+	}
+}
+
+@PART[bluedog_SOLRAD8]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier3/samples$
+	}
+}
+
+@PART[bluedog_Transit2A]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		@dataCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/data$
+		@sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/bdbtier2/samples$
+	}
+}
+
+// ============================================================================
 // Custom habitat surface/volume
 // by schrema
 // reviewed by HaullyGames at Fev 13th 2018
@@ -26,29 +590,104 @@
 // Laboratory
 // by Maxzhao1999
 // reviewed by HaullyGames at Fev 13th 2018
+// Updated to BDB 1.8 by Bellabong
 // ============================================================================
 
-@PART[bluedog_MOL_Lab]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
+@PART[bluedog_Apollo_Block3_Capsule,bluedog_Spacelab_ERM,bluedog_Skylab_OWS_Wet]:NEEDS[Bluedog_DB,FeatureScience]:FIRST
 {
+	MODULE
+	{
+		name = Configure
+		title = Crew Experiments
+	}
+}
+
+@PART[bluedog_MiniLab_Lab,bluedog_MOL_Lab_New]:HAS[@MODULE[ModuleScienceLab]]:NEEDS[Bluedog_DB,FeatureScience]:FIRST
+{
+	MODULE
+	{
+		name = Configure
+		title = Laboratory Experiments
+	}
+}
+
+@PART[bluedog_Skylab_Workshop,bluedog_Skylab_WetWorkshop,bluedog_spacelab_forwardAdapter]:HAS[@MODULE[ModuleScienceLab]]:NEEDS[Bluedog_DB,FeatureScience]:FIRST
+{
+	MODULE
+	{
+		name = Configure
+		title = Laboratory Experiments
+	}
+}
+
+@PART[bluedog_Skylab_Workshop,bluedog_Skylab_WetWorkshop,bluedog_spacelab_forwardAdapter]:HAS[@MODULE[Configure]:HAS[#title[Laboratory?Experiments]]]:AFTER[zzzzKerbalismDefault]
+{
+	@MODULE[Configure]:HAS[#title[Laboratory?Experiments]]
+	{
+		%slots = 2
+
+		@UPGRADES
+		{
+			@UPGRADE[Lab-Upgrade1]
+			{
+				%slots = 4
+			}
+		}
+	}
+}
+@PART[bluedog_MiniLab_Lab]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
+{
+	!MODULE[Laboratory] {}
 	MODULE
 	{
 		name = Laboratory
 		researcher = Scientist
 		analysis_rate = 0.003 // 3 kbps (since it's a smaller and earlier along the tech tree)
-		ec_rate = 0.9
+		ec_rate = 0.5
 	}
 
 	!MODULE[ModuleScienceLab] {}
 	!MODULE[ModuleScienceConverter] {}
 }
 
-@PART[bluedog_Skylab_OWS]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
+@PART[bluedog_MOL_Lab_New]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
 {
+	!MODULE[Laboratory] {}
 	MODULE
 	{
 		name = Laboratory
 		researcher = Scientist
-		analysis_rate = 0.012 // 12 kbps (since it's a smaller and earlier along the tech tree)
+		analysis_rate = 0.006 // 6 kbps (since it's a smaller and earlier along the tech tree)
+		ec_rate = 0.7
+	}
+
+	!MODULE[ModuleScienceLab] {}
+	!MODULE[ModuleScienceConverter] {}
+}
+
+@PART[bluedog_MOL_1p5mStationSegment]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
+{
+	!MODULE[Laboratory] {}
+	MODULE
+	{
+		name = Laboratory
+		researcher = Scientist
+		analysis_rate = 0.004 // 6 kbps (since it's a smaller and earlier along the tech tree)
+		ec_rate = 0.7
+	}
+
+	!MODULE[ModuleScienceLab] {}
+	!MODULE[ModuleScienceConverter] {}
+}
+
+@PART[bluedog_Skylab_Workshop,bluedog_Skylab_WetWorkshop]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
+{
+	!MODULE[Laboratory] {}
+	MODULE
+	{
+		name = Laboratory
+		researcher = Scientist
+		analysis_rate = 0.024 // 24 kbps
 		ec_rate = 3.6
 	}
 
@@ -56,14 +695,15 @@
 	!MODULE[ModuleScienceConverter] {}
 }
 
-@PART[bluedog_Spacelab_ERM]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
+@PART[bluedog_spacelab_forwardAdapter]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
 {
+	!MODULE[Laboratory] {}
 	MODULE
 	{
 		name = Laboratory
 		researcher = Scientist
-		analysis_rate = 0.003 // 3 kbps (since it's a smaller and earlier along the tech tree)
-		ec_rate = 0.9
+		analysis_rate = 0.012 // 12 kbps
+		ec_rate = 1.4
 	}
 
 	!MODULE[ModuleScienceLab] {}
@@ -75,7 +715,7 @@
 // added by Gordon Dry
 // ============================================================================
 
-@PART[bluedog_MOL_Hab]:NEEDS[Bluedog_DB,FeatureHabitat,FeatureRadiation]:AFTER[zzzKerbalismDefault]
+@PART[bluedog_MOL_Lab_New]:NEEDS[Bluedog_DB,FeatureHabitat,FeatureRadiation]:AFTER[zzzKerbalismDefault]
 {
 	MODULE
 	{
@@ -97,6 +737,338 @@
 	}
 }
 
+@PART[bluedog_Gemini_TwoRoomStationModule]:NEEDS[Bluedog_DB,FeatureHabitat,FeatureRadiation]:AFTER[zzzKerbalismDefault]
+{
+	MODULE
+	{
+		name = Sickbay
+		resource = _SickbayRDU
+		title = RDU
+		desc = The Radiation Detoxication Unit (RDU) uses EC and Oxygen to reduce the effects of radiation poisoning.
+		slots = 0
+
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = Upgrade-HitchhikerRDU
+				techRequired__ = advScienceTech
+				slots = 1
+			}
+		}
+	}
+}
+
+@PART[bluedog_Skylab_Workshop,bluedog_Skylab_WetWorkshop]:NEEDS[Bluedog_DB,FeatureHabitat,FeatureRadiation]:AFTER[zzzKerbalismDefault]
+{
+	@description ^= :$: Can be upgraded to contain a Treadmill with Vibration Isolation Stabilization System (TVIS). 
+	@tags ^= :$: exercise: 
+
+	MODULE:NEEDS[FeatureComfort]
+	{
+		name = Comfort
+		desc = A treadmill designed to permit exercise in zero-g is included. The crew will love it.
+		bonus = exercise
+	}
+
+	MODULE:NEEDS[FeatureReliability]
+	{
+		name = Reliability
+		type = Comfort
+		title = Treadmill
+		repair = Engineer
+		mtbf = 36288000
+		extra_cost = 0.25
+		extra_mass = 0.05
+	}
+}
+
+// ============================================================================
+// Fuel Cells
+// added by Gordon Dry
+// ============================================================================
+
+@PART[bluedog_Spacelab_ERM]:NEEDS[HabTech2,ProfileDefault]:FOR[KerbalismDefault]
+{
+	@tags ^= :$: fuel cell fuelcell water recycler waste processor anthraquinone soe: 
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _MonopropFuelCell
+		title = Fuel cell
+		capacity = #$/CrewCapacity$
+		@capacity *= 5
+	    valve_i = 2
+		running = false
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _FuelCell
+		title = Fuel Cell
+		capacity = #$/CrewCapacity$
+	    valve_i = 1
+		running = false
+	}
+
+	MODULE
+	{
+		name = Configure
+		title = Fuel Cell
+		slots = 1
+
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = Upgrade-Slots
+				techRequired__ = advElectrics
+				slots = 2
+			}
+		}
+
+		SETUP
+		{
+			name = Monoprop Oxygen Fuel Cell
+			desc = Burns <b>MonoPropellant</b> and <b>Oxygen</b> gas, producing <b>Water</b> and <b>Nitrogen</b> gas as by-products.
+			tech = survivability
+			mass = 0.1
+			cost = 1000
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _MonopropFuelCell
+			}
+		}
+
+		SETUP
+		{
+			name = Hydrogen Oxygen Fuel Cell
+			desc = Burns <b>Hydrogen</b> gas and <b>Oxygen</b> gas, producing <b>Water</b> as a by-product.
+			tech = advElectrics
+			mass = 0.05
+			cost = 2500
+			valve_i = 1
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _FuelCell
+			}
+		}
+	}
+
+	MODULE:NEEDS[FeatureReliability]
+	{
+		name = Reliability
+		type = ProcessController
+		title = Fuel Cell
+		redundancy = Power Generation
+		repair = Engineer
+		mtbf = 72576000
+		extra_cost = 0.1
+		extra_mass = 0.05
+	}
+
+	-MODULE[ProcessController]:HAS[#resource[?Scrubber]] { }
+	-MODULE[ProcessController]:HAS[#resource[?PressureControl]] { }
+
+	-MODULE[ProcessController]:HAS[#resource[?WaterRecycler]] { }
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterRecycler
+		title = Water recycler
+		capacity = #$/CrewCapacity$
+		running = false
+	}
+
+	-MODULE[ProcessController]:HAS[#resource[?WasteProcessor]] { }
+	MODULE
+	{
+		name = ProcessController
+		resource = _WasteProcessor
+		title = Waste processor
+		capacity = #$/CrewCapacity$
+		running = false
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _Anthraquinone
+		title = Anthraquinone process
+		capacity = #$/CrewCapacity$
+		running = false
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _SOE
+		title = SOE
+		capacity = #$/CrewCapacity$
+		running = false
+	}
+
+	MODULE
+	{
+		name = Configure
+		title = Habitat recyclers
+		slots = 1
+
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = Upgrade-Slots
+				techRequired__ = recycling
+				slots = 2
+			}
+			UPGRADE
+			{
+				name__ = Upgrade-Slots_advScienceTech
+				techRequired__ = advScienceTech
+				slots = 3
+			}
+		}
+
+		SETUP
+		{
+			name = Water Recycler
+			desc = Filter impurities out of <b>WasteWater</b>.
+			tech = recycling
+			mass = 0.05
+			cost = 500
+
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _WaterRecycler
+			}
+
+			RESOURCE
+			{
+				name = WasteWater
+				amount = 0
+				maxAmount = #$/CrewCapacity$
+				@maxAmount *= 5
+			}
+		}
+
+		SETUP
+		{
+			name = Waste Processor
+			desc = Extract <b>Ammonia</b> out of decomposing organic <b>Waste</b>.
+			tech = shortTermHabitation
+			mass = 0.05
+			cost = 500
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _WasteProcessor
+			}
+
+			RESOURCE
+			{
+				name = Waste
+				amount = 0
+				maxAmount = #$/CrewCapacity$
+				@maxAmount *= 5
+			}
+		}
+
+		SETUP
+		{
+			name = Anthraquinone Process
+			desc = Synthesize <b>Oxidizer</b> using a redox of <b>Oxygen</b> and <b>Hydrogen</b>.
+			tech = advScienceTech
+			mass = 0.1
+			cost = 3500
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _Anthraquinone
+			}
+		}
+
+		SETUP
+		{
+			name = Solid Oxide Electrolysis
+			desc = Transform <b>CarbonDioxide</b> into <b>Oxygen</b> and <b>Shielding</b>.
+			tech = experimentalScience
+			mass = 0.15
+			cost = 4500
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _SOE
+			}
+		}
+	}
+	
+	// MODULE:NEEDS[FeatureReliability]
+	// {
+		// name = Reliability
+		// type = ProcessController
+		// title = Habitat recyclers
+		// repair = Engineer
+		// mtbf = 72576000
+		// extra_cost = 0.1
+		// extra_mass = 0.1
+	// }
+}
+
+@PART[bluedog_Spacelab_ERM]:NEEDS[HabTech2,FeatureHabitat,FeatureComfort]:AFTER[zzzKerbalismDefault]
+{
+	@tags ^= :$: sickbay shower napkin: 
+
+	MODULE
+	{
+		name = Sickbay
+		resource = _SickbayShower
+		title = Shower
+		desc = This is not a shower - but close your eyes and believe it. A dry napkin is placed into a special package. The package is filled with warm water from the onboard water dispenser. When the dry napkin is soaked, the astronaut breaks the package open and 'showers' with the home-made wet wipe.
+		mass = 0.001
+		cost = 50
+		slots = 0
+		// techRequired = recycling
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = Upgrade-ColumbusShower
+				techRequired__ = recycling
+				slots = 1
+			}
+		}
+	}
+
+	MODULE
+	{
+		name = Reliability
+		type = Sickbay
+		title = Shower
+		redundancy = Life Support
+		repair = true // anyone 
+		mtbf = 10368000
+		extra_cost = 0.005
+		extra_mass = 0.001
+	} 
+}
 // ============================================================================
 // Standalone Antennas
 // by ValynEritai
@@ -180,38 +1152,25 @@
 // Geiger counter
 // ============================================================================
 
-// use our own geiger counter experiment definition
-!EXPERIMENT_DEFINITION:HAS[#id[bd_GeigerCounter]]:NEEDS[Bluedog_DB,FeatureScience] {}
+// More parts now have Geigercounters, time for a catch-all patch
 
-@PART[Bluedog_Geiger,bluedog_Pioneer1]:NEEDS[Bluedog_DB]
+@PART[*]:HAS[@MODULE:HAS[#experimentID[bd_GeigerCounter]]]:NEEDS[FeatureScience]
 {
-	MODULE
+	!MODULE:HAS[#experimentID[bd_GeigerCounter]]	{}
 	{
-		name = Sensor
-		type = radiation
-		pin = needle
+		MODULE
+		{
+			name = Sensor
+			type = radiation
+			pin = needle
+		}
 	}
-}
-
-@PART[Bluedog_Geiger,bluedog_Pioneer1]:NEEDS[Bluedog_DB,FeatureScience]
-{
-	!MODULE[ModuleAnimateGeneric] {}
-	!MODULE[*ModuleScience*] {}
-
 	MODULE
 	{
 		name = Experiment
 		experiment_id = geigerCounter
 	}
-}
-
-//  Changes experimentlist to accomodate change in experiment_id
-@CONTRACT_TYPE[BDB_Gemini]:NEEDS[Bluedog_DB,FeatureScience]
-{
-	@DATA[experimentslist]
-	{
-		%experiments = [logmmImpacts, geigerCounter]
-	}
+	
 }
 
 // ============================================================================
@@ -227,7 +1186,22 @@
 		@maxAmount = 12
 	}
 }
-
+@PART[bluedog_Pioneer_1,bluedog_Pioneer_4,bluedog_Juno1_Explorer1,bluedog_WRESAT]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@RESOURCE[ElectricCharge]
+	{
+		@amount *= 16
+		@maxAmount *= 16
+	}
+}
+@PART[bluedog*,Bluedog*]:HAS[@MODULE[ModuleCommand]:HAS[#minimumCrew[0]]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@RESOURCE[ElectricCharge]
+	{
+		@amount *= 5
+		@maxAmount *= 5
+	}
+}
 // =========================================================
 // BD ScienceDefs
 // =========================================================
@@ -261,176 +1235,60 @@
 {
     MODULE
     {
-      name = Experiment
-      experiment_id = bd_atm
-      data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_atm/size$
-      @data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_atm/duration$
-      ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_atm/ec_rate$
-      allow_shrouded = False
+		name = Experiment
+		experiment_id = bd_atm
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_atm/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_atm/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_atm],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_atm/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_atm],~name[Experiment]]/xmitDataScalar$
+		allow_shrouded = False
     }
 
-    !MODULE:HAS[#experimentID[bd_atm]] {}
+    !MODULE:HAS[#experimentID[bd_atm],~name[Experiment]] {}
 }
 
 // =========================================================
-// id = bd_oso
-// title = Orbital Sun Observations
+// id = bd_bioexp
+// title = Biological experiments
 // =========================================================
 @KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
 {
 	%BDB
 	{
-		bd_oso
+		bd_bioexp
 		{
-			size = 8000
+			size = 3858
 			value = 15
-			duration = 453600 // 21 days
-			ec_rate = 0.3
+			duration = 22820
+			ec_rate = 0.36
 		}
 	}
 }
 
-@EXPERIMENT_DEFINITION:HAS[#id[bd_oso]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+@EXPERIMENT_DEFINITION:HAS[#id[bd_bioexp]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
 {
-	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/value$
-	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/size$
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_bioexp/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_bioexp/size$
 	@dataScale /= #$baseValue$
+
 }
 
-@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_oso]]]:NEEDS[Bluedog_DB,FeatureScience]
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_bioexp]]]:NEEDS[Bluedog_DB,FeatureScience]
 {
     MODULE
     {
-      name = Experiment
-      experiment_id = bd_oso
-      data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/size$
-      @data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/duration$
-      ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/ec_rate$
-      allow_shrouded = False
-	  restriction = Sunlight
+		name = Experiment
+		experiment_id = bd_bioexp
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_bioexp/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_bioexp/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_bioexp],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_bioexp/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_bioexp],~name[Experiment]]/xmitDataScalar$
+		@anim_deploy:HAS[@MODULE[*Module*]:HAS[#animationName]] = #$../MODULE:HAS[#animationName],~name[Experiment]]/animationName$
     }
 
-    !MODULE:HAS[#experimentID[bd_oso]] {}
-}
-
-// =========================================================
-// id = logmmImpacts
-// title = Micrometeoroid Impact Data
-// =========================================================
-@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
-{
-	%BDB
-	{
-		logmmImpacts
-		{
-			size = 3200
-			value = 6
-			duration = 21600
-			ec_rate = 0.02
-		}
-	}
-}
-
-@EXPERIMENT_DEFINITION:HAS[#id[logmmImpacts]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
-{
-	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/logmmImpacts/value$
-	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/logmmImpacts/size$
-	@dataScale /= #$baseValue$
-}
-
-@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[logmmImpacts]]]:NEEDS[Bluedog_DB,FeatureScience]
-{
-    MODULE
-    {
-      name = Experiment
-      experiment_id = logmmImpacts
-      data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/logmmImpacts/size$
-      @data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/logmmImpacts/duration$
-      ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/logmmImpacts/ec_rate$
-      allow_shrouded = False
-    }
-
-    !MODULE:HAS[#experimentID[logmmImpacts]] {}
-}
-
-// =========================================================
-// id = logIonTrap
-// title = Charged Particle Data
-// =========================================================
-@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
-{
-	%BDB
-	{
-		logIonTrap
-		{
-			size = 4200
-			value = 6
-			duration = 129600 // 36 hours
-			ec_rate = 0.08
-		}
-	}
-}
-
-@EXPERIMENT_DEFINITION:HAS[#id[logIonTrap]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
-{
-	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/logIonTrap/value$
-	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/logIonTrap/size$
-	@dataScale /= #$baseValue$
-}
-
-@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[logIonTrap]]]:NEEDS[Bluedog_DB,FeatureScience]
-{
-    MODULE
-    {
-      name = Experiment
-      experiment_id = logIonTrap
-      data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/logIonTrap/size$
-      @data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/logIonTrap/duration$
-      ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/logIonTrap/ec_rate$
-      allow_shrouded = False
-	  anim_deploy = deploy
-    }
-
-    !MODULE:HAS[#experimentID[logIonTrap]] {}
-}
-
-// =========================================================
-// id = bd_massSpec
-// title = Mass Spectrum Analysis
-// =========================================================
-@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
-{
-	%BDB
-	{
-		bd_massSpec
-		{
-			size = 5200
-			value = 8
-			duration = 7200 // hours
-			ec_rate = 0.44
-		}
-	}
-}
-
-@EXPERIMENT_DEFINITION:HAS[#id[bd_massSpec]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
-{
-	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/value$
-	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/size$
-	@dataScale /= #$baseValue$
-}
-
-@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_massSpec]]]:NEEDS[Bluedog_DB,FeatureScience]
-{
-    MODULE
-    {
-      name = Experiment
-      experiment_id = bd_massSpec
-      data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/size$
-      @data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/duration$
-      ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/ec_rate$
-    }
-
-    !MODULE:HAS[#experimentID[bd_massSpec]] {}
+    !MODULE:HAS[#experimentID[bd_bioexp],~name[Experiment]] {}
 }
 
 // =========================================================
@@ -453,64 +1311,146 @@
 
 @EXPERIMENT_DEFINITION:HAS[#id[bd_camera]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
 {
-	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/value$
-	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/size$
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/size$
 	@dataScale /= #$baseValue$
+	IncludeExperiment = bd_Photometer //If you can take a picture of a planet you can see how bright it is. 
+}
+
+@PART[bluedog_cameraLowTech]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_camera]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_camera
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/duration$
+		@data_rate *= 0.25
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/ec_rate$
+		@ec_rate = *= 0.25
+    }
+
+    !MODULE:HAS[#experimentID[bd_camera],~name[Experiment]] {}
+}
+@PART[ca_filmCamera]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_camera]]]:NEEDS[Bluedog_DB,CoatlAerospace,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_camera
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/duration$
+		@data_rate *= 0.25
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/ec_rate$
+		@ec_rate = *= 0.25
+    }
+
+    !MODULE:HAS[#experimentID[bd_camera],~name[Experiment]] {}
+}
+
+@PART[bluedog_Pioneer_4,bluedog_Gemini_LunarRecon_Camera,bluedog_Pioneer4,bluedog_mariner10_camera,bluedog_mariner10_cameraStandalone,bluedog_Clementine_Sensors]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_camera]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_camera
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_camera],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_camera],~name[Experiment]]/xmitDataScalar$
+    }
+
+    !MODULE:HAS[#experimentID[bd_camera],~name[Experiment]] {}
 }
 
 @PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_camera]]]:NEEDS[Bluedog_DB,FeatureScience]
 {
     MODULE
     {
-      name = Experiment
-      experiment_id = bd_camera
-      data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/size$
-      @data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/duration$
-      ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/ec_rate$
-	  anim_deploy = Camera
+		name = Experiment
+		experiment_id = bd_camera
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_camera],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_camera/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_camera],~name[Experiment]]/xmitDataScalar$
+		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
     }
 
-    !MODULE:HAS[#experimentID[bd_camera]] {}
+    !MODULE:HAS[#experimentID[bd_camera],~name[Experiment]] {}
 }
 
 // =========================================================
-// id = bd_IRspec
-// title = Infrared Spectrometry Data
+// id = bd_gammaRay
+// title = Gamma Ray Spectrometry
 // =========================================================
+
 @KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
 {
 	%BDB
 	{
-		bd_IRspec
+		bd_gammaRay
 		{
-			size = 6512
-			value = 6
-			duration = 14400 // 4 hours
-			ec_rate = 0.2
+			size = 8000
+			value = 14
+			duration = 453600 // 21 days
+			ec_rate = 1.2
 		}
 	}
 }
-
-@EXPERIMENT_DEFINITION:HAS[#id[bd_IRspec]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+@EXPERIMENT_DEFINITION:HAS[#id[bd_gammaRay]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
 {
-	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/value$
-	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/size$
-	@dataScale /= #$baseValue$
+        @baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_gammaRay/value$
+        @dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_gammaRay/size$
+        @dataScale /= #$baseValue$
+		
+		KERBALISM_EXPERIMENT
+		{
+			VirtualBiome = NoBiome
+			VirtualBiome = InnerBelt
+			VirtualBiome = OuterBelt
+			VirtualBiome = Magnetosphere
+			VirtualBiome = Storm
+			VirtualBiome = Interstellar
+			Situation = InSpaceLow@VirtualBiomes
+			Situation = InSpaceHigh@VirtualBiomes
+		}
 }
 
-@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_IRspec]]]:NEEDS[Bluedog_DB,FeatureScience]
+@PART[bluedog_Explorer_11]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_gammaRay]]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
 {
-    MODULE
-    {
-      name = Experiment
-      experiment_id = bd_IRspec
-      data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/size$
-      @data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/duration$
-      ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/ec_rate$
-	  allow_shrouded = False
-    }
+	MODULE
+	{
+		name = Experiment
+		experiment_id = bd_gammaRay
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_gammaRay/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_gammaRay/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_gammaRay],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_gammaRay/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_gammaRay],~name[Experiment]]/xmitDataScalar$
+		allow_shrouded = False
+	}
 
-    !MODULE:HAS[#experimentID[bd_IRspec]] {}
+	!MODULE[*ModuleScience*]:HAS[#experimentID[bd_gammaRay],~name[Experiment]] {}
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_gammaRay]]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = bd_gammaRay
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_gammaRay/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_gammaRay/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_gammaRay],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_gammaRay/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_gammaRay],~name[Experiment]]/xmitDataScalar$
+		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+		allow_shrouded = False
+	}
+
+	!MODULE:HAS[#experimentID[bd_gammaRay],~name[Experiment]] {}
 }
 
 // =========================================================
@@ -550,100 +1490,235 @@
 	  allow_shrouded = False
     }
 
-    !MODULE:HAS[#experimentID[bd_hydrometer]] {}
+    !MODULE:HAS[#experimentID[bd_hydrometer],~name[Experiment]] {}
 }
 
 // =========================================================
-// id = bd_surveillance
-// title =  Orbital Surveillance Data
+// id = bd_ionElec
+// title = Ionization and Electrostatic Analysis
+// =========================================================
+
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	%BDB
+	{
+		bd_ionElec
+		{
+			size = 2048
+			value = 5
+			duration = 14400 // 4 hours
+			ec_rate = 0.2
+		}
+	}
+}
+@EXPERIMENT_DEFINITION:HAS[#id[bd_ionElec]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+        @baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_ionElec/value$
+        @dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_ionElec/size$
+        @dataScale /= #$baseValue$
+		
+		KERBALISM_EXPERIMENT
+		{
+			VirtualBiome = NoBiome
+			VirtualBiome = InnerBelt
+			VirtualBiome = OuterBelt
+			VirtualBiome = Magnetosphere
+			VirtualBiome = Storm
+			VirtualBiome = Interstellar
+			VirtualBiome = Reentry 
+			Situation = FlyingHigh@VirtualBiomes
+			Situation = Space@VirtualBiomes
+		}
+}
+
+@PART[bluedog_Ranger_Block1_ElectroAnalyzer_Experiment]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_ionElec]]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = bd_ionElec
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_ionElec/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_ionElec/duration$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_ionElec/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_ionElec],~name[Experiment]]/xmitDataScalar$
+		allow_shrouded = False
+		anim_deploy = deploy
+		restriction = bluedog_Ranger_Block1_ElectroAnalyzer_Device1,bluedog_Ranger_Block1_ElectroAnalyzer_Device2
+
+	}
+
+	!MODULE:HAS[#experimentID[bd_ionElec],~name[Experiment]] {}
+}
+
+@PART[bluedog_Explorer_8,bluedog_LOFTI,bluedog_Injun1]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_ionElec]]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = bd_ionElec
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_ionElec/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_ionElec/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_ionElec],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_ionElec/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_ionElec],~name[Experiment]]/xmitDataScalar$
+		allow_shrouded = False
+	}
+
+	!MODULE:HAS[#experimentID[bd_ionElec],~name[Experiment]] {}
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_ionElec]]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = bd_ionElec
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_ionElec/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_ionElec/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_ionElec],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_ionElec/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_ionElec],~name[Experiment]]/xmitDataScalar$
+		allow_shrouded = False
+		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+	}
+
+	!MODULE:HAS[#experimentID[bd_ionElec],~name[Experiment]] {}
+}
+
+// =========================================================
+// id = bd_IRradiometer
+// title = Infrared Radiation Data // Balanced against DMs Multispectral analyzer
 // =========================================================
 @KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
 {
 	%BDB
 	{
-		bd_surveillance
+		bd_IRradiometer
 		{
-			size = 8512
-			value = 12
-			duration = 129600 // 36 hours
-			ec_rate = 0.25
+			size = 6512
+			value = 6
+			duration = 151200
+			ec_rate = 0.2
 		}
 	}
 }
 
-@EXPERIMENT_DEFINITION:HAS[#id[bd_surveillance]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+@EXPERIMENT_DEFINITION:HAS[#id[bd_IRradiometer]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
 {
-	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_surveillance/value$
-	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_surveillance/size$
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRradiometer/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRradiometer/size$
 	@dataScale /= #$baseValue$
 }
 
-@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_surveillance]]]:NEEDS[Bluedog_DB,FeatureScience]
+@PART[bd_IRradiometer,bluedog_Mariner2_Radiometer,bluedog_Clementine_Sensors]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_IRradiometer]]]:NEEDS[Bluedog_DB,FeatureScience]
 {
     MODULE
     {
-      name = Experiment
-      experiment_id = bd_surveillance
-      data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_surveillance/size$
-      @data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_surveillance/duration$
-      ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_surveillance/ec_rate$
-	  allow_shrouded = False
-	  anim_deploy = deploy
+		name = Experiment
+		experiment_id = bd_IRradiometer
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRradiometer/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRradiometer/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_IRradiometer],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRradiometer/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_IRradiometer],~name[Experiment]]/xmitDataScalar$
+		allow_shrouded = False
     }
 
-    !MODULE:HAS[#experimentID[bd_surveillance]] {}
+    !MODULE:HAS[#experimentID[bd_IRradiometer],~name[Experiment]] {}
 }
 
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_IRradiometer]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_IRradiometer
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRradiometer/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRradiometer/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_IRradiometer],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRradiometer/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_IRradiometer],~name[Experiment]]/xmitDataScalar$
+		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+		allow_shrouded = False
+    }
+
+    !MODULE:HAS[#experimentID[bd_IRradiometer],~name[Experiment]] {}
+}
 
 // =========================================================
-// id = bd_rpws
-// title = Radio Plasma Wave Data
+// id = bd_IRspec
+// title = Infrared Spectrometry Data
 // =========================================================
 @KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
 {
 	%BDB
 	{
-		bd_rpws
+		bd_IRspec
 		{
-			size = 1800
-			value = 9
-			duration = 648000 // 30 days
-			ec_rate = 0.3
+			size = 6512
+			value = 6
+			duration = 151200
+			ec_rate = 0.2
 		}
 	}
 }
 
-@EXPERIMENT_DEFINITION:HAS[#id[bd_rpws]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+@EXPERIMENT_DEFINITION:HAS[#id[bd_IRspec]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
 {
-	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_rpws/value$
-	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_rpws/size$
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/size$
 	@dataScale /= #$baseValue$
 }
 
-@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_rpws]]]:NEEDS[Bluedog_DB,FeatureScience]
+@PART[bluedog_IRspec,bluedog_Nimbus_Instrument_SIS,bluedog_Skylab_IRspec]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_IRspec]]]:NEEDS[Bluedog_DB,FeatureScience]
 {
     MODULE
     {
-      name = Experiment
-      experiment_id = bd_rpws
-      data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_rpws/size$
-      @data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_rpws/duration$
-      ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_rpws/ec_rate$
-      allow_shrouded = False
-	  anim_deploy = deploy
+		name = Experiment
+		experiment_id = bd_IRspec
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_IRspec],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_IRspec],~name[Experiment]]/xmitDataScalar$
+		allow_shrouded = False
     }
-
-    !MODULE:HAS[#experimentID[bd_rpws]] {}
+    !MODULE:HAS[#experimentID[bd_IRspec],~name[Experiment]] {}
 }
 
-// switch to DMOS version if it is present
-!EXPERIMENT_DEFINITION:HAS[#id[bd_rpws]]:NEEDS[Bluedog_DB,DMagicOrbitalScience,FeatureScience] {}
-@PART[*]:HAS[@MODULE[Experiment]:HAS[#experiment_id[bd_rpws]]]:NEEDS[Bluedog_DB,DMagicOrbitalScience,FeatureScience]
+@PART[mer_rsp,ca_KLIR]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_IRspec]]]:NEEDS[Bluedog_DB,CoatlAerospace,FeatureScience]
 {
-	@MODULE[Experiment]
-	{
-		@experiment_id = rpwsScan
-	}
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_IRspec
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_IRspec],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_IRspec],~name[Experiment]]/xmitDataScalar$
+		allow_shrouded = False
+    }
+
+    !MODULE:HAS[#experimentID[bd_IRspec],~name[Experiment]] {}
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_IRspec]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_IRspec
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_IRspec],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_IRspec/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_IRspec],~name[Experiment]]/xmitDataScalar$
+		anim_deploy = #$../MODULE:HAS[#animationName,~name[Experiment]]/animationName$
+		allow_shrouded = False
+    }
+
+    !MODULE:HAS[#experimentID[bd_IRspec],~name[Experiment]] {}
 }
 
 // =========================================================
@@ -669,22 +1744,71 @@
 	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_magScan/value$
 	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_magScan/size$
 	@dataScale /= #$baseValue$
+	
+	KERBALISM_EXPERIMENT
+	{
+		VirtualBiome = NoBiome
+		VirtualBiome = InnerBelt
+		VirtualBiome = OuterBelt
+		VirtualBiome = Magnetosphere
+		VirtualBiome = Storm
+		VirtualBiome = Interstellar
+		Situation = InSpaceLow@VirtualBiomes
+		Situation = InSpaceHigh@VirtualBiomes
+	}
+}
+
+@PART[bluedog_Ranger_Block1_Truss,bluedog_Mariner2_Truss,bluedog_mariner4Antenna,bluedog_Sputnik3_Core]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_magScan]]]:NEEDS[Bluedog_DB,FeatureScience,!DMagicOrbitalScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_magScan
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_magScan/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_magScan/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_magScan],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_magScan/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_magScan],~name[Experiment]]/xmitDataScalar$
+		allow_shrouded = False
+	}
+
+    !MODULE:HAS[#experimentID[bd_magScan],~name[Experiment]] {}
+}
+
+
+@PART[ca_argo-mk2-mast]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_magScan]]]:NEEDS[Bluedog_DB,CoatlAerospace,FeatureScience,!DMagicOrbitalScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_magScan
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_magScan/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_magScan/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_magScan],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_magScan/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_magScan],~name[Experiment]]/xmitDataScalar$
+		allow_shrouded = False
+	}
+
+    !MODULE:HAS[#experimentID[bd_magScan],~name[Experiment]] {}
 }
 
 @PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_magScan]]]:NEEDS[Bluedog_DB,FeatureScience]
 {
     MODULE
     {
-      name = Experiment
-      experiment_id = bd_magScan
-      data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_magScan/size$
-      @data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_magScan/duration$
-      ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_magScan/ec_rate$
-      allow_shrouded = False
-	  anim_deploy = deploy
-    }
+		name = Experiment
+		experiment_id = bd_magScan
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_magScan/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_magScan/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_magScan],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_magScan/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_magScan],~name[Experiment]]/xmitDataScalar$
+		anim_deploy = #$../MODULE:HAS[#animationName,~name[Experiment]]/animationName$
+		allow_shrouded = False
+	}
 
-    !MODULE:HAS[#experimentID[bd_magScan]] {}
+    !MODULE:HAS[#experimentID[bd_magScan],~name[Experiment]] {}
 }
 
 @PART[bluedog_foldingMag]:NEEDS[Bluedog_DB,FeatureScience]
@@ -699,31 +1823,1028 @@
 !EXPERIMENT_DEFINITION:HAS[#id[bd_magScan]]:NEEDS[Bluedog_DB,DMagicOrbitalScience,FeatureScience] {}
 @PART[*]:HAS[@MODULE[Experiment]:HAS[#experiment_id[bd_magScan]]]:NEEDS[Bluedog_DB,DMagicOrbitalScience,FeatureScience]
 {
-	%MODULE[Experiment]
+	@MODULE[Experiment]:HAS[#experiment_id[bd_magScan]]
 	{
 		@experiment_id = magScan
 	}
 }
 
 // =========================================================
-// bluedog_MiniGoo
+// id = bd_mapping
+// title =  Orbital Mapping Data
 // =========================================================
-@PART[bluedog_MiniGoo]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[zzzKerbalismDefault]
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
 {
-	@MODULE[Experiment]
+	%BDB
 	{
-		anim_deploy = bluedog_MiniGoo_Emit
+		bd_mapping
+		{
+			size = 2048
+			value = 10
+			duration = 129600
+			ec_rate = 0.25
+		}
+	}
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[bd_mapping]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_mapping/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_mapping/size$
+	@dataScale /= #$baseValue$
+	
+	KERBALISM_EXPERIMENT
+	{
+		SampleMass = 0.0005
+		VirtualBiome = NoBiome
+		VirtualBiome = NorthernHemisphere
+		VirtualBiome = SouthernHemisphere
+		Situation = InSpaceLow@Biomes
+		Situation = InSpaceHigh@VirtualBiomes
+	}
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_mapping]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_mapping
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_mapping/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_mapping/duration$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_mapping/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_mapping],~name[Experiment]]/xmitDataScalar$
+		allow_shrouded = False
+		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+		sample_amount = 2
+		requirements = SunAngleMax:55
+	}
+
+    !MODULE:HAS[#experimentID[bd_mapping],~name[Experiment]] {}
+}
+
+// =========================================================
+// id = bd_massSpec
+// title = Mass Spectrum Analysis
+// =========================================================
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	%BDB
+	{
+		bd_massSpec
+		{
+			size = 5200
+			value = 8
+			duration = 7200
+			ec_rate = 0.44
+		}
+	}
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[bd_massSpec]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/size$
+	@dataScale /= #$baseValue$
+}
+
+@PART[Bluedog_MassSpec]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_massSpec]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_massSpec
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/duration$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/ec_rate$
+	}
+
+    !MODULE:HAS[#experimentID[bd_massSpec],~name[Experiment]] {}
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_massSpec]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_massSpec
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/duration$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_massSpec/ec_rate$
+		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+	}
+
+    !MODULE:HAS[#experimentID[bd_massSpec],~name[Experiment]] {}
+}
+
+// =========================================================
+// id = bd_microwaveSpec
+// title = Microwave Spectrometry Data
+// =========================================================
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	%BDB
+	{
+		bd_microwaveSpec
+		{
+			size = 512
+			value = 3
+			duration = 3600
+			ec_rate = 0.2
+		}
+	}
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[bd_microwaveSpec]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_microwaveSpec/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_microwaveSpec/size$
+	@dataScale /= #$baseValue$
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_microwaveSpec]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_microwaveSpec
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_microwaveSpec/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_microwaveSpec/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_microwaveSpec],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_microwaveSpec/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_microwaveSpec],~name[Experiment]]/xmitDataScalar$
+		allow_shrouded = False
+    }
+
+    !MODULE:HAS[#experimentID[bd_microwaveSpec],~name[Experiment]] {}
+}
+
+@PART[bluedog_Nimbus_Instrument_ESMR,bluedog_Nimbus_Instrument_SMMR]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+	%MODULE[Experiment]
+	{
+		%anim_deploy = deploy
 	}
 }
 
 // =========================================================
-// bluedog_Agena_MaterialsBay
+// id = bd_orbitalScope
+// title = Orbital Images
 // =========================================================
-@PART[bluedog_Agena_MaterialsBay]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[zzzKerbalismDefault]
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	%BDB
+	{
+		bd_orbitalScope
+		{
+			size = 1100
+			value = 8
+			duration = 151200 // 7 days
+			ec_rate = 0.2
+		}
+	}
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[bd_orbitalScope]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_orbitalScope/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_orbitalScope/size$
+	@dataScale /= #$baseValue$
+}
+
+@PART[ca_telescope_a,mer_rsp]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_orbitalScope]]]:NEEDS[Bluedog_DB,CoatlAerospace,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_orbitalScope
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_orbitalScope/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_orbitalScope/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_orbitalScope],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_orbitalScope/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_orbitalScope],~name[Experiment]]/xmitDataScalar$
+		allow_shrouded = False
+		requirements = SunAngleMax:55
+    }
+
+    !MODULE:HAS[#experimentID[bd_orbitalScope],~name[Experiment]] {}
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_orbitalScope]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_orbitalScope
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_orbitalScope/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_orbitalScope/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_orbitalScope],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_orbitalScope/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_orbitalScope],~name[Experiment]]/xmitDataScalar$
+		anim_deploy = #$../MODULE:HAS[#experimentActionName,~name[Experiment]]/experimentActionName$
+		allow_shrouded = False
+		requirements = SunAngleMax:55
+    }
+
+    !MODULE:HAS[#experimentID[bd_orbitalScope],~name[Experiment]] {}
+}
+
+// switch to DMOS version if it is present
+!EXPERIMENT_DEFINITION:HAS[#id[bd_orbitalScope]]:NEEDS[Bluedog_DB,DMagicOrbitalScience,FeatureScience] {}
+@PART[*]:HAS[@MODULE[Experiment]:HAS[#experiment_id[bd_orbitalScope]]]:NEEDS[Bluedog_DB,DMagicOrbitalScience,FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+	@MODULE[Experiment]:HAS[#experiment_id[bd_orbitalScope]]
+	{
+		@experiment_id = scopeScan
+	}
+}
+
+// =========================================================
+// id = bd_oso
+// title = Orbital Sun Observations
+// =========================================================
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	%BDB
+	{
+		bd_oso
+		{
+			size = 8000
+			value = 15
+			duration = 453600 // 21 days
+			ec_rate = 0.3
+		}
+	}
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[bd_oso]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/size$
+	@dataScale /= #$baseValue$
+}
+
+@PART[bluedog_Skylab_ATM,bluedog_Transit5_SolarScience]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_oso]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_oso
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/duration$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/ec_rate$
+		allow_shrouded = False
+		restriction = Sunlight
+    }
+
+    !MODULE:HAS[#experimentID[bd_oso],~name[Experiment]] {}
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_oso]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_oso
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/duration$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_oso/ec_rate$
+		anim_deploy = #$../MODULE:HAS[#animationName,~name[Experiment]]/animationName$
+		allow_shrouded = False
+		restriction = Sunlight
+    }
+
+    !MODULE:HAS[#experimentID[bd_oso],~name[Experiment]] {}
+}
+
+// =========================================================
+// id = bd_Photometer
+// title = Photometry Data
+// =========================================================
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	%BDB
+	{
+		bd_Photometer
+		{
+			size = 512
+			value = 3
+			duration = 600
+			ec_rate = 0.5
+		}
+	}
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[bd_Photometer]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_Photometer/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_Photometer/size$
+	@dataScale /= #$baseValue$
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_Photometer]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = bd_Photometer
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_Photometer/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_Photometer/duration$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_Photometer/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_Photometer],~name[Experiment]]/xmitDataScalar$
+		@anim_deploy:HAS[@MODULE[*ModuleScience*]:HAS[#animationName,#experimentID[bd_Photometer]]] = #$../MODULE:HAS[#experimentID[bd_Photometer],~name[Experiment]]/animationName$
+		allow_shrouded = False
+	}
+
+	!MODULE:HAS[#experimentID[bd_Photometer],~name[Experiment]] {}
+}
+
+// =========================================================
+// id = bd_radarAltimeter
+// title = Radar Altimetry Data
+// =========================================================
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	%BDB
+	{
+		bd_radarAltimeter
+		{
+			size = 2512
+			value = 6
+			duration = 129600
+			ec_rate = 0.25
+		}
+	}
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[bd_radarAltimeter]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_radarAltimeter/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_radarAltimeter/size$
+	@dataScale /= #$baseValue$
+}
+@PART[bluedog_Skylab_radarAltimeter,bluedog_Clementine_Sensors,bluedog_Apollo_SIMbay_radar]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_radarAltimeter]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_radarAltimeter
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_radarAltimeter/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_radarAltimeter/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_radarAltimeter],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_radarAltimeter/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_radarAltimeter],~name[Experiment]]/xmitDataScalar$
+	}
+
+    !MODULE:HAS[#experimentID[bd_radarAltimeter],~name[Experiment]] {}
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_radarAltimeter]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_radarAltimeter
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_radarAltimeter/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_radarAltimeter/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_radarAltimeter],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_radarAltimeter/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_radarAltimeter],~name[Experiment]]/xmitDataScalar$
+		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+	}
+
+    !MODULE:HAS[#experimentID[bd_radarAltimeter],~name[Experiment]] {}
+}
+
+// =========================================================
+// id = bd_rpws
+// title = Radio Plasma Wave Data
+// =========================================================
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	%BDB
+	{
+		bd_rpws
+		{
+			size = 1800
+			value = 9
+			duration = 648000 // 30 days
+			ec_rate = 0.3
+		}
+	}
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[bd_rpws]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_rpws/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_rpws/size$
+	@dataScale /= #$baseValue$
+	
+	KERBALISM_EXPERIMENT
+	{
+		VirtualBiome = NoBiome
+		VirtualBiome = InnerBelt
+		VirtualBiome = OuterBelt
+		VirtualBiome = Magnetosphere
+		VirtualBiome = Storm
+		VirtualBiome = Interstellar
+		Situation = InSpaceLow@VirtualBiomes
+		Situation = InSpaceHigh@VirtualBiomes
+	}
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_rpws]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_rpws
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_rpws/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_rpws/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_rpws],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_rpws/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_rpws],~name[Experiment]]/xmitDataScalar$
+		allow_shrouded = False
+		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/experimentActionName$
+	}
+
+    !MODULE:HAS[#experimentID[bd_rpws],~name[Experiment]] {}
+}
+
+// switch to DMOS version if it is present
+!EXPERIMENT_DEFINITION:HAS[#id[bd_rpws]]:NEEDS[Bluedog_DB,DMagicOrbitalScience,FeatureScience] {}
+@PART[*]:HAS[@MODULE[Experiment]:HAS[#experiment_id[bd_rpws]]]:NEEDS[Bluedog_DB,DMagicOrbitalScience,FeatureScience]
+{
+	@MODULE[Experiment]:HAS[#experiment_id[bd_rpws]]
+	{
+		@experiment_id = rpwsScan
+	}
+}
+
+// =========================================================
+// id = bd_solarWind
+// title = Solar Wind Measurement
+// =========================================================
+
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	%BDB
+	{
+		bd_solarWind
+		{
+			size = 2048
+			value = 6
+			duration = 3600 // 1 hour
+			ec_rate = 0.5
+		}
+	}
+}
+@EXPERIMENT_DEFINITION:HAS[#id[bd_solarWind]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+        @baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_solarWind/value$
+        @dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_solarWind/size$
+        @dataScale /= #$baseValue$
+		
+		KERBALISM_EXPERIMENT
+		{
+			VirtualBiome = NoBiome
+			VirtualBiome = InnerBelt
+			VirtualBiome = OuterBelt
+			VirtualBiome = Magnetosphere
+			VirtualBiome = Storm
+			VirtualBiome = Interstellar
+			Situation = Space@VirtualBiomes
+		}
+}
+
+@PART[bluedog_Skylab_ATM]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_solarWind]]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = bd_solarWind
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_solarWind/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_solarWind/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_solarWind],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_solarWind/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_solarWind],~name[Experiment]]/xmitDataScalar$
+		restriction = Sunlight
+	}
+
+	!MODULE[*ModuleScience*]:HAS[#experimentID[bd_solarWind],~name[Experiment]] {}
+}
+
+@PART[ca_stereoBoom,ca_SWIS,bluedog_Transit5_SolarScience]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_solarWind]]]:NEEDS[CoatlAerospace,Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = bd_solarWind
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_solarWind/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_solarWind/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_solarWind],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_solarWind/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_solarWind],~name[Experiment]]/xmitDataScalar$
+		restriction = Sunlight
+	}
+
+	!MODULE[*ModuleScience*]:HAS[#experimentID[bd_solarWind],~name[Experiment]] {}
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_solarWind]]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = bd_solarWind
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_solarWind/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_solarWind/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_solarWind],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_solarWind/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_solarWind],~name[Experiment]]/xmitDataScalar$
+		anim_deploy = #$../MODULE:HAS[#animationName,~name[Experiment]]/animationName$
+		restriction = Sunlight
+	}
+
+	!MODULE[*ModuleScience*]:HAS[#experimentID[bd_solarWind],~name[Experiment]] {}
+}
+
+// =========================================================
+// id = bd_surveillance
+// title =  Orbital Surveillance Data
+// =========================================================
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	%BDB
+	{
+		bd_surveillance
+		{
+			size = 4096
+			value = 12
+			duration = 129600 // 36 hours
+			ec_rate = 0.25
+		}
+	}
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[bd_surveillance]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_surveillance/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_surveillance/size$
+	@dataScale /= #$baseValue$
+	KERBALISM_EXPERIMENT
+	{
+		SampleMass = 0.0005
+		VirtualBiome = NoBiome
+		VirtualBiome = NorthernHemisphere
+		VirtualBiome = SouthernHemisphere
+		Situation = InSpaceLow@Biomes
+		Situation = InSpaceHigh@VirtualBiomes
+	}
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_surveillance]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_surveillance
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_surveillance/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_surveillance/duration$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_surveillance/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_surveillance],~name[Experiment]]/xmitDataScalar$
+		allow_shrouded = False
+		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+	}
+
+    !MODULE:HAS[#experimentID[bd_surveillance],~name[Experiment]] {}
+}
+
+// =========================================================
+// id = bd_TVcamera
+// title = TV camera imaging
+// =========================================================
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	%BDB
+	{
+		bd_TVcamera
+		{
+			size = 29290768
+			value = 365
+			duration = 94608000 // 3 years of broadcasting
+			ec_rate = 1.5
+		}
+	}
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[bd_TVcamera]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_TVcamera/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_TVcamera/size$
+	@dataScale /= #$baseValue$
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_TVcamera]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_TVcamera
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_TVcamera/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_TVcamera/duration$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_TVcamera/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_TVcamera],~name[Experiment]]/xmitDataScalar$
+		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+		allow_shrouded = false
+    }
+
+    !MODULE:HAS[#experimentID[bd_TVcamera],~name[Experiment]] {}
+}
+
+// =========================================================
+// id = bd_UVscope
+// title = High Resolution Ultraviolet Imaging
+// =========================================================
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	%BDB
+	{
+		bd_UVscope
+		{
+			size = 289386462
+			value = 400
+			duration = 230083200 //Standard for Space Telescopes I guess
+			ec_rate = 1.91
+		}
+	}
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[bd_UVscope]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVscope/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVscope/size$
+	@dataScale /= #$baseValue$
+}
+
+@PART[ca_explorer]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_UVscope]]]:NEEDS[CoatlAerospace,Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_UVscope
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVscope/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVscope/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_UVscope],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVscope/ec_rate$
+		allow_shrouded = false
+    }
+
+    !MODULE:HAS[#experimentID[bd_UVscope],~name[Experiment]] {}
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_UVscope]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = bd_UVscope
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVscope/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVscope/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_UVscope],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVscope/ec_rate$
+		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+		allow_shrouded = false
+    }
+
+    !MODULE:HAS[#experimentID[bd_UVscope],~name[Experiment]] {}
+}
+
+// =========================================================
+// id = bd_UVspec
+// title = Ultraviolet and Atmospheric Analysis
+// =========================================================
+
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	%BDB
+	{
+		bd_UVspec
+		{
+			size = 6512
+			value = 6
+			duration = 151200
+			ec_rate = 0.2
+		}
+	}
+}
+@EXPERIMENT_DEFINITION:HAS[#id[bd_UVspec]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+        @baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVspec/value$
+        @dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVspec/size$
+        @dataScale /= #$baseValue$
+}
+
+@PART[bluedog_Ranger_Block1_LymanAlphaTelescope,bluedog_mariner10_camera,bluedog_mariner10_cameraStandalone,bluedog_mariner10_UVspectrometer,mer_rsp,ca_explorer,ca_vor_camera,bluedog_Transit5_UVSpectrometer,bluedog_Apollo_SIMbay_UVspectrometer]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_UVspec]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = bd_UVspec
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVspec/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVspec/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_UVspec],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVspec/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_UVspec],~name[Experiment]]/xmitDataScalar$
+		allow_shrouded = false
+	}
+
+	!MODULE:HAS[#experimentID[bd_UVspec],~name[Experiment]] {}
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_UVspec]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = bd_UVspec
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVspec/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVspec/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_UVspec],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_UVspec/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_UVspec],~name[Experiment]]/xmitDataScalar$
+		anim_deploy = #$../MODULE:HAS[#animationName,~name[Experiment]]/animationName$
+		allow_shrouded = false
+	}
+
+	!MODULE:HAS[#experimentID[bd_UVspec],~name[Experiment]] {}
+}
+
+// =========================================================
+// id = bd_weather
+// title = Orbital Weather Observation
+// =========================================================
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	%BDB
+	{
+		bd_weather
+		{
+			size = 8830080
+			value = 730 // .2 Sci a day
+			duration = 315360000 // 10 years of weather reporting
+			ec_rate = 0.5
+		}
+	}
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[bd_weather]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_weather/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_weather/size$
+	@dataScale /= #$baseValue$
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_weather]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = bd_weather
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_weather/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_weather/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_weather],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_weather/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[bd_weather],~name[Experiment]]/xmitDataScalar$
+	}
+
+    !MODULE:HAS[#experimentID[bd_weather],~name[Experiment]] {}
+}
+
+// =========================================================
+// id = bd_XrayImaging
+// title = X-Ray Imaging
+// =========================================================
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	%BDB
+	{
+		bd_XrayImaging
+		{
+			size = 289386462
+			value = 400
+			duration = 230083200
+			ec_rate = 1.91
+		}
+	}
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[bd_XrayImaging]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_XrayImaging/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_XrayImaging/size$
+	@dataScale /= #$baseValue$
+}
+
+@PART[bluedog_SOLRAD,bluedog_SOLRAD8]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_XrayImaging]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = bd_XrayImaging
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_XrayImaging/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_XrayImaging/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_XrayImaging],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_XrayImaging/ec_rate$
+	}
+
+    !MODULE:HAS[#experimentID[bd_XrayImaging],~name[Experiment]] {}
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[bd_XrayImaging]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = bd_XrayImaging
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_XrayImaging/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_XrayImaging/duration$
+		@data_rate *= #$../MODULE:HAS[#experimentID[bd_XrayImaging],~name[Experiment]]/xmitDataScalar$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_XrayImaging/ec_rate$
+		anim_deploy = #$../MODULE:HAS[#experimentID,~name[Experiment]]/animationName$
+	}
+
+    !MODULE:HAS[#experimentID[bd_XrayImaging],~name[Experiment]] {}
+}
+
+// =========================================================
+// id = logmmImpacts
+// title = Micrometeoroid Impact Data
+// =========================================================
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	%BDB
+	{
+		logmmImpacts
+		{
+			size = 3200
+			value = 6
+			duration = 21600
+			ec_rate = 0.02
+		}
+	}
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[logmmImpacts]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/logmmImpacts/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/logmmImpacts/size$
+	@dataScale /= #$baseValue$
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[logmmImpacts]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+      name = Experiment
+      experiment_id = logmmImpacts
+      data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/logmmImpacts/size$
+      @data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/logmmImpacts/duration$
+      ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/logmmImpacts/ec_rate$
+      allow_shrouded = False
+    }
+
+    !MODULE:HAS[#experimentID[logmmImpacts],~name[Experiment]] {}
+}
+
+// =========================================================
+// id = logIonTrap
+// title = Charged Particle Data
+// =========================================================
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[Bluedog_DB,FeatureScience]
+{
+	%BDB
+	{
+		logIonTrap
+		{
+			size = 4200
+			value = 6
+			duration = 129600 // 36 hours
+			ec_rate = 0.08
+		}
+	}
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[logIonTrap]]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@baseValue = #$@KERBALISM_EXPERIMENT_VALUES/BDB/logIonTrap/value$
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/BDB/logIonTrap/size$
+	@dataScale /= #$baseValue$
+}
+
+@PART[*]:HAS[@MODULE[*ModuleScience*]:HAS[#experimentID[logIonTrap]]]:NEEDS[Bluedog_DB,FeatureScience]
+{
+    MODULE
+    {
+		name = Experiment
+		experiment_id = logIonTrap
+		data_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/logIonTrap/size$
+		@data_rate /= #$@KERBALISM_EXPERIMENT_VALUES/BDB/logIonTrap/duration$
+		ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/logIonTrap/ec_rate$
+		@ec_rate *= #$../MODULE:HAS[#experimentID[logIonTrap],~name[Experiment]]/xmitDataScalar$
+		allow_shrouded = False
+	}
+
+    !MODULE:HAS[#experimentID[logIonTrap],~name[Experiment]] {}
+}
+
+
+// =========================================================
+// bluedog_MiniGoo
+// =========================================================
+
+@PART[bluedog_MiniGoo]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	MODULE
+	{
+		name = HardDrive
+		experiment_id = mysteryGoo
+		dataCapacity = 0
+		sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/PRIVATE_DRIVES/bluedog_MiniGoo/samples$
+
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = Goo-Storage-Upgrade
+				techRequired__ = #$../../../@KERBALISM_HDD_SIZES/BDB/PRIVATE_DRIVES/bluedog_MiniGoo/UpgradeTech$
+				sampleCapacity = #$../../#sampleCapacity$
+				@sampleCapacity *= #$../../../@KERBALISM_HDD_SIZES/BDB/PRIVATE_DRIVES/bluedog_MiniGoo/SampleReservoirUpgrade$
+			}
+		}
+	}
+}
+
+@PART[bluedog_MiniGoo]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+	@MODULE[Experiment]:HAS[#experiment_id[mysteryGoo]]
+	{
+		@anim_deploy = bluedog_MiniGoo_Emit
+		@data_rate /= 4
+		@UPGRADES
+		{
+			@UPGRADE[Goo-Storage-Upgrade]
+			{
+				%sample_amount = 2
+			}
+		}
+	}
+}
+
+// =========================================================
+// bluedog_GATV_MaterialsBay
+// =========================================================
+
+@PART[bluedog_GATV_MaterialsBay]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	MODULE
+	{
+		name = HardDrive
+		experiment_id = mobileMaterialsLab
+		dataCapacity = 0
+		sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/PRIVATE_DRIVES/bluedog_GATV_MaterialsBay/samples$
+
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = MatBay-Storage-Upgrade
+				techRequired__ = #$../../../@KERBALISM_HDD_SIZES/BDB/PRIVATE_DRIVES/bluedog_GATV_MaterialsBay/UpgradeTech$
+				sampleCapacity = #$../../#sampleCapacity$
+				@sampleCapacity *= #$../../../@KERBALISM_HDD_SIZES/BDB/PRIVATE_DRIVES/bluedog_GATV_MaterialsBay/SampleReservoirUpgrade$
+			}
+		}
+	}
+}
+
+@PART[bluedog_GATV_MaterialsBay]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[zzzKerbalismDefault]
 {
 	%MODULE[Experiment]
 	{
-		anim_deploy = deploy
+		@anim_deploy = deploy
+		@restriction = bluedog_GATV_NuclearPackage,bluedog_GATV_MMDetector
+	}
+}
+
+// =========================================================
+// bluedog_GATV_NuclearPackage
+// =========================================================
+@PART[bluedog_GATV_NuclearPackage]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+	%MODULE[Experiment]
+	{
+		sample_collecting = true
+		@anim_deploy = deploy
 	}
 }
 
@@ -736,4 +2857,355 @@
 	{
 		anim_deploy = deploy
 	}
+}
+
+// =========================================================
+// SOO-SEP Solar Experiment Package
+// =========================================================
+@PART[bluedog_OSO_Experiment]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+	%MODULE[Experiment]
+	{
+		%anim_deploy = deploy
+	}
+}
+
+// =========================================================
+// HLR-OOG-OPEP Mass Spectrometer
+// =========================================================
+@PART[bluedog_OGO_OPEP]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+	%MODULE[Experiment]
+	{
+		%anim_deploy = deploy
+	}
+}
+
+// =========================================================
+// HLR-OOG-EP1 Ion Trap Boom
+// =========================================================
+@PART[bluedog_OGO_ExperimentBoom_3]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+	%MODULE[Experiment]
+	{
+		%anim_deploy = deploy
+	}
+}
+
+// =========================================================
+// HLR-OOG-EP2 Gravimetric Scanner
+// =========================================================
+@PART[bluedog_OGO_ExperimentBoom_2]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+	%MODULE[Experiment]
+	{
+		%anim_deploy = deploy
+	}
+}
+
+// =========================================================
+// HLR-OOG-EP4 Ionization and Electrostatic Analysis Boom
+// =========================================================
+@PART[bluedog_OGO_ExperimentBoom_1]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+	%MODULE[Experiment]
+	{
+		%anim_deploy = deploy
+	}
+}
+
+// =========================================================
+// HLR-OOG-EP6 Gamma Ray Spectrometer
+// =========================================================
+@PART[bluedog_OGO_LongBoom_Ball]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+	%MODULE[Experiment]
+	{
+		%anim_deploy = deploy
+	}
+}
+
+// =========================================================
+// Burke-2-GRSP Gamma Ray Spectrometer
+// =========================================================
+@PART[bluedog_Ranger_Block2_GammaRaySpectrometer]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+	%MODULE[Experiment]
+	{
+		%anim_deploy = deploy
+	}
+}
+
+// =========================================================
+// Ranger Block 2 Radar Altimeter
+// =========================================================
+@PART[bluedog_Ranger_Block2_GammaRaySpectrometer]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+	%MODULE[Experiment]
+	{
+		%anim_deploy = deploy
+	}
+}
+
+// =========================================================
+// Deployable Ion Sensors
+// =========================================================
+@PART[bluedog_Pioneer6_IonSensor,]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+	%MODULE[Experiment]
+	{
+		%anim_deploy = deploy
+	}
+}
+
+// ============================================================================
+// Patches to the pods
+//
+// ============================================================================
+
+@PART[bluedog_Corona_Pod]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+    @MODULE[HardDrive]
+    {
+        @sampleCapacity = 2
+    }
+}
+
+@PART[bluedog_Hexagon_Mk8_Capsule]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+    @MODULE[HardDrive]
+    {
+        @sampleCapacity = 4
+    }
+}
+
+// ============================================================================
+//	Balance Keyholedata rate to tech level
+// ============================================================================
+
+@PART[bluedog_Keyhole_Camera_KH1]:HAS[@MODULE[Experiment]:HAS[#experimentID[bd_mapping]]]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
+{
+    @MODULE[Experiment]
+    {
+		@data_rate *= 0.25
+		@sample_amount = 2
+	}
+}
+
+@PART[bluedog_Keyhole_Camera_KH4]:HAS[@MODULE[Experiment]:HAS[#experimentID[bd_mapping]]]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
+{
+    @MODULE[Experiment]
+    {
+		@data_rate *= 0.75
+		@sample_amount = 4
+	}
+}
+
+@PART[bluedog_Keyhole_Camera_KH4B]:HAS[@MODULE[Experiment]:HAS[#experimentID[bd_mapping]]]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
+{
+    @MODULE[Experiment]
+    {
+		@data_rate *= 1.0
+		@sample_amount = 4
+	}
+}
+
+@PART[bluedog_Keyhole_Camera_KH7]:HAS[@MODULE[Experiment]:HAS[#experimentID[bd_surveillance]]]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
+{
+    @MODULE[Experiment]
+    {
+		@data_rate *= 1.25
+		@sample_amount = 6
+	}
+}
+
+@PART[bluedog_Keyhole_Camera_KH8]:HAS[@MODULE[Experiment]:HAS[#experimentID[bd_surveillance]]]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
+{
+    @MODULE[Experiment]
+    {
+		@data_rate *= 1.45
+		@sample_amount = 6
+	}
+}
+
+@PART[bluedog_Hexagon_Camera]:HAS[@MODULE[Experiment]:HAS[#experimentID[bd_surveillance]]]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
+{
+    @MODULE[Experiment]
+    {
+		@data_rate *= 1.60
+		@sample_amount = 16
+	}
+}
+
+@PART[bluedog_Hexagon_MappingCamera]:HAS[@MODULE[Experiment]:HAS[#experimentID[bd_mapping]]]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
+{
+    @MODULE[Experiment]
+    {
+		@data_rate *= 1.3
+		@sample_amount = 8
+	}
+}
+
+@PART[bluedog_MOL_Camera]:HAS[@MODULE[Experiment]:HAS[#experimentID[bd_surveillance]]]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
+{
+    @MODULE[Experiment]
+    {
+		@data_rate *= 1.25
+		@sample_amount = 0
+		@sample_collecting = true
+	}
+}
+
+@PART[bluedog_Nimbus_Instrument_TOMS]:HAS[@MODULE[Experiment]:HAS[#experimentID[bd_weather]]]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
+{
+    @MODULE[Experiment]
+    {
+		@restriction = bluedog_Nimbus_Instrument_ERB
+	}
+}
+
+@PART[Bluedog_DB/Parts/ProbeExpansion/Nimbus/bluedog_Nimbus_Instrument_SAMS]:HAS[@MODULE[Experiment]:HAS[#experimentID[bd_weather]]]:NEEDS[Bluedog_DB,FeatureScience]:AFTER[KerbalismDefault]
+{
+    @MODULE[Experiment]
+    {
+		@restriction = bluedog_Nimbus_Instrument_TOMS,bluedog_Nimbus_Instrument_ERB
+	}
+}
+
+// ============================================================================
+// Radiation emitters
+// ============================================================================
+
+
+@PART[bluedog_RTG_SNAP3]:NEEDS[Bluedog_DB,FeatureRadiation]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Emitter
+		radiation = 0.0000017775
+	}
+	
+  	MODULE:NEEDS[ProfileDefault]
+	{
+		name = ProcessController
+		resource = _RTG
+		title = RTG
+		capacity = 0.3
+		running = true
+		toggle = false
+	}
+	
+	!MODULE[ModuleGenerator] {}
+	!MODULE[ModuleCoreHeat] {}
+}
+
+@PART[bluedog_Transit5_SNAP9A]:NEEDS[Bluedog_DB,FeatureRadiation]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Emitter
+		radiation = 0.0000017775
+	}
+	
+  	MODULE:NEEDS[ProfileDefault]
+	{
+		name = ProcessController
+		resource = _RTG
+		title = RTG
+		capacity = 0.66
+		running = true
+		toggle = false
+	}
+	
+	!MODULE[ModuleGenerator] {}
+	!MODULE[ModuleCoreHeat] {}
+}
+
+
+@PART[bluedog_RTG_SNAP19]:NEEDS[Bluedog_DB,FeatureRadiation]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Emitter
+		radiation = 0.0000077775
+	}
+	
+  	MODULE:NEEDS[ProfileDefault]
+	{
+		name = ProcessController
+		resource = _RTG
+		title = RTG
+		capacity = 1.25
+		running = true
+		toggle = false
+	}
+	
+	!MODULE[ModuleGenerator] {}
+	!MODULE[ModuleCoreHeat] {}
+}
+
+@PART[bluedog_Transit5_RTG]:NEEDS[Bluedog_DB,FeatureRadiation]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Emitter
+		radiation = 0.0000177775
+	}
+	
+  	MODULE:NEEDS[ProfileDefault]
+	{
+		name = ProcessController
+		resource = _RTG
+		title = RTG
+		capacity = 1.25
+		running = true
+		toggle = false
+	}
+	
+	!MODULE[ModuleGenerator] {}
+	!MODULE[ModuleCoreHeat] {}
+}
+
+@PART[bluedog_RTG_SNAP19_Nimbus]:NEEDS[Bluedog_DB,FeatureRadiation]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Emitter
+		radiation = 0.0000377775
+	}
+	
+  	MODULE:NEEDS[ProfileDefault]
+	{
+		name = ProcessController
+		resource = _RTG
+		title = RTG
+		capacity = 2.55
+		running = true
+		toggle = false
+	}
+	
+	!MODULE[ModuleGenerator] {}
+	!MODULE[ModuleCoreHeat] {}
+}
+
+@PART[bluedog_RTG_SNAP19_Quad]:NEEDS[Bluedog_DB,FeatureRadiation]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Emitter
+		radiation = 0.0000777775
+	}
+	
+  	MODULE:NEEDS[ProfileDefault]
+	{
+		name = ProcessController
+		resource = _RTG
+		title = RTG
+		capacity = 5.15
+		running = true
+		toggle = false
+	}
+	
+	!MODULE[ModuleGenerator] {}
+	!MODULE[ModuleCoreHeat] {}
 }

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -597,7 +597,7 @@
 	{
 		@SUBTYPE[MonoProp]
 		{
-			%volumeAdded = 0.958974
+			%volumeAdded = 0.96
 			%tankType = bdbSupplyOxygen
 		}
 	}
@@ -609,12 +609,12 @@
 	{
 		@SUBTYPE[None]
 		{
-			%volumeAdded = 0.479487
+			%volumeAdded = 0.48
 			%tankType = bdbSupplyOxygen
 		}
 		@SUBTYPE[MonoProp]
 		{
-			%volumeAdded = 0.479487
+			%volumeAdded = 0.48
 			%tankType = bdbSupplyOxygen
 		}
 	}

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -591,7 +591,6 @@
 // GameData\Bluedog_DB_Extras\Fuel Cell\CRP fuel cells.cfg
 // ============================================================================
 
-
 @PART[bluedog_Apollo_Block2_SM]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]]:NEEDS[FeatureHabitat]:FOR[KerbalismDefault]
 {
 	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[fuelCellSwitch]]

--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -2894,15 +2894,15 @@
 
 @PART[bluedog_GATV_MaterialsBay]:NEEDS[Bluedog_DB,FeatureScience]:FOR[zzzKerbalismDefault]
 {
-	%MODULE[HardDrive]
+	MODULE
 	{
-		%experiment_id = mobileMaterialsLab
-		%dataCapacity = 0
-		%sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/PRIVATE_DRIVES/bluedog_GATV_MaterialsBay/samples$
+		name = HardDrive
+		experiment_id = mobileMaterialsLab
+		dataCapacity = 0
+		sampleCapacity = #$@KERBALISM_HDD_SIZES/BDB/PRIVATE_DRIVES/bluedog_GATV_MaterialsBay/samples$
 
-		%UPGRADES
+		UPGRADES
 		{
-			-UPGRADE:HAS[#name__[MatBay-Storage-Upgrade]]
 			UPGRADE
 			{
 				name__ = MatBay-Storage-Upgrade


### PR DESCRIPTION
The old one creates 2 MM patching errors, see https://github.com/Kerbalism/Kerbalism/issues/705#issuecomment-969204817

This one is especially for https://github.com/CobaltWolf/Bluedog-Design-Bureau/tree/apollo-saturn-revamp and should be merged as soon as BDB has a new release with it.

The two patches targeted are for
bluedog_Skylab_VFB_telescope
bluedog_Skylab_solar_radio_burst_antenna

Please test.