### PR TITLE
The temporary but working launch clamps EC gen Planner fix

### DIFF
--- a/GameData/KerbalismConfig/Profiles/Default.cfg
+++ b/GameData/KerbalismConfig/Profiles/Default.cfg
@@ -487,9 +487,9 @@ Profile
     title = #KERBALISM_Process_ZeroGravityShower
     modifier = _SickbayShower
     input = ElectricCharge@0.014049975308642 //  sustained heating @4.184 J/gK to 313 K from 273 K storage temperature,
-	input = Water@0.0000839507  // 5.44 L per shower, source : http://www.marsjournal.org/contents/2006/0005/files/rapp_mars_2006_0005.pdf
-	output = WasteWater@0.0000839507  // water content fully recovered
-	interval = 64800.0 // one shower every 18 hours / 3 days
+  input = Water@0.0000839507  // 5.44 L per shower, source : http://www.marsjournal.org/contents/2006/0005/files/rapp_mars_2006_0005.pdf
+  output = WasteWater@0.0000839507  // water content fully recovered
+  interval = 64800.0 // one shower every 18 hours / 3 days
     cures = stress@0.00000000463
   }
 
@@ -499,9 +499,9 @@ Profile
     title = #KERBALISM_Process_WasherDryer
     modifier = _SickbayLaundry // one complete kerbal outfit is 0.77 kg source : https://ttu-ir.tdl.org/ttu-ir/bitstream/handle/2346/72928/ICES_2017_106.pdf?sequence=1&isAllowed=y
     input = ElectricCharge@0.0463715278 //  13.36 kWh / 3.06 kg clothing
-	input = Water@0.0763900389  // 22 L per 3.06 kg clothes
-	output = WasteWater@0.0763900389  // water content fully recovered
-	interval = 259200.0 // kerbals change clothes every 72 hours / 12 days
+  input = Water@0.0763900389  // 22 L per 3.06 kg clothes
+  output = WasteWater@0.0763900389  // water content fully recovered
+  interval = 259200.0 // kerbals change clothes every 72 hours / 12 days
     cures = stress@0.00000000463
   }
 
@@ -633,7 +633,7 @@ PARTUPGRADE:NEEDS[ProfileDefault]
         // crew going eva will need the volume their bodies displaced within the vessel replaced with N2 to correct pressure drop,
         // vise versa when entering from eva the pressure will increase due to the volume of the Kerbal displacing
         // the internal vessel atmosphere, excess is vented overboard.
-	    // The pressure controller can be disabled to save N2 that will be used replacing the Kerbals volume,
+      // The pressure controller can be disabled to save N2 that will be used replacing the Kerbals volume,
         name = Nitrogen
         amount = #$/CrewCapacity$
         maxAmount = #$/CrewCapacity$
@@ -708,10 +708,10 @@ PARTUPGRADE:NEEDS[ProfileDefault]
     }
 
     SETUP
-		{
-			name = None
-			desc = #KERBALISM_None_desc//Empty slot for mass and cost savings.
-		}
+    {
+      name = None
+      desc = #KERBALISM_None_desc//Empty slot for mass and cost savings.
+    }
   }
 }
 
@@ -874,7 +874,7 @@ PARTUPGRADE:NEEDS[ProfileDefault]
         id_field = resource
         id_value = _WasteProcessor
       }
-	}
+  }
 
     SETUP
     {
@@ -1144,7 +1144,7 @@ PARTUPGRADE:NEEDS[ProfileDefault]
     SETUP
     {
       name = Xenon Gas  // Stored at 85 bar (1250psi) when full
-						// see https://www.cobham.com/mission-systems/composite-pressure-solutions/space-systems/xenon-propellant-tank-datasheet/
+            // see https://www.cobham.com/mission-systems/composite-pressure-solutions/space-systems/xenon-propellant-tank-datasheet/
       desc = #KERBALISM_PressurizedTank_desc6//Store pressurized <b>Xenon</b> gas @ 85 bar.
       tech = ionPropulsion
 
@@ -1171,7 +1171,7 @@ PARTUPGRADE:NEEDS[ProfileDefault]
   {
     name = Greenhouse
     // Please note the Greenhouse is its own process and does not work like the standard processes, for example the WasteAtmosphere and
-	// CarbonDioxide INPUT_RESOURCE parameters work together and can internally interchange information depending on conditions, see below.
+  // CarbonDioxide INPUT_RESOURCE parameters work together and can internally interchange information depending on conditions, see below.
 
     crop_resource = Food                // name of resource produced by harvests
     // Based on design targets from Prototype Lunar Greenhouse (see https://www.ag.arizona.edu/lunargreenhouse/MidReviews.htm ):
@@ -1291,19 +1291,19 @@ PARTUPGRADE:NEEDS[ProfileDefault]
 // Launch clamps
 // ============================================================================
 
-@PART[launchClamp1]:NEEDS[ProfileDefault]:FOR[KerbalismDefault]
+@PART[*]:HAS[@MODULE[ModuleGenerator]:HAS[@OUTPUT_RESOURCE[ElectricCharge]],@MODULE[LaunchClamp]]:NEEDS[ProfileDefault]:FOR[KerbalismDefault]
 {
   MODULE
   {
     name = ProcessController
     resource = _ECGen
     title = #KERBALISM_PowerSupply_title//Power supply
-    capacity = 1.0
+    capacity = #$/MODULE[ModuleGenerator]:HAS[@OUTPUT_RESOURCE[ElectricCharge]]/OUTPUT_RESOURCE[ElectricCharge]/rate$
     running = true
-    toggle = false
+    toggle = true
   }
 
-  !MODULE[ModuleGenerator] {}
+  !MODULE[ModuleGenerator]:HAS[@OUTPUT_RESOURCE[ElectricCharge]] {}
 }
 
 // ============================================================================
@@ -1786,17 +1786,17 @@ PARTUPGRADE:NEEDS[ProfileDefault]
 // You get a slot upgrade, and you get a slot upgrade, EVERYONE gets a slot upgrade!
 // Had to fix unintended shenenigans, assuming whoever patched this initially never expected multiple configures on the same part.
 @PART[*]:HAS[@MODULE[Configure]]:NEEDS[ProfileDefault]:FOR[zzzKerbalismDefault]
-{ 	@MODULE[Configure]:HAS[#title[Pod]] 			{ @UPGRADES { @UPGRADE:HAS[#name__[Upgrade?Slots]] { @slots = #$../../slots$
+{   @MODULE[Configure]:HAS[#title[Pod]]       { @UPGRADES { @UPGRADE:HAS[#name__[Upgrade?Slots]] { @slots = #$../../slots$
       @slots += 1 } } }
-	@MODULE[Configure]:HAS[#title[Life?Support]] 	{ @UPGRADES { @UPGRADE:HAS[#name__[Upgrade?Slots]] { @slots = #$../../slots$
+  @MODULE[Configure]:HAS[#title[Life?Support]]   { @UPGRADES { @UPGRADE:HAS[#name__[Upgrade?Slots]] { @slots = #$../../slots$
       @slots += 1 } } }
-	@MODULE[Configure]:HAS[#title[Chemical?Plant]] 	{ @UPGRADES { @UPGRADE:HAS[#name__[Upgrade?Slots]] { @slots = #$../../slots$
+  @MODULE[Configure]:HAS[#title[Chemical?Plant]]   { @UPGRADES { @UPGRADE:HAS[#name__[Upgrade?Slots]] { @slots = #$../../slots$
       @slots += 1 } } }
 }
 
 // tweak number of slots
-@PART[MK1CrewCabin|Mark2Cockpit|cupola]:NEEDS[ProfileDefault]:FOR[zzzKerbalismDefault] 		{ @MODULE[Configure]:HAS[#title[Pod]] { @slots = 1 } }
-@PART[mk3Cockpit_Shuttle]:NEEDS[ProfileDefault]:FOR[zzzKerbalismDefault] 						{ @MODULE[Configure]:HAS[#title[Pod]] { @slots = 3 } }
+@PART[MK1CrewCabin|Mark2Cockpit|cupola]:NEEDS[ProfileDefault]:FOR[zzzKerbalismDefault]     { @MODULE[Configure]:HAS[#title[Pod]] { @slots = 1 } }
+@PART[mk3Cockpit_Shuttle]:NEEDS[ProfileDefault]:FOR[zzzKerbalismDefault]             { @MODULE[Configure]:HAS[#title[Pod]] { @slots = 3 } }
 
 // ============================================================================
 // ISRU drills

--- a/GameData/KerbalismConfig/Profiles/Default.cfg
+++ b/GameData/KerbalismConfig/Profiles/Default.cfg
@@ -951,8 +951,8 @@ PARTUPGRADE:NEEDS[ProfileDefault]
       RESOURCE
       {
         name = Food
-        amount = 0.7221584
-        maxAmount = 0.7221584
+        amount = 1.056
+        maxAmount = 1.056
         @amount *= #$/ContainerVolume$
         @maxAmount *= #$/ContainerVolume$
       }
@@ -960,8 +960,8 @@ PARTUPGRADE:NEEDS[ProfileDefault]
       RESOURCE
       {
         name = Water
-        amount = 0.2778416
-        maxAmount = 0.2778416
+        amount = 0.528
+        maxAmount = 0.528
         @amount *= #$/ContainerVolume$
         @maxAmount *= #$/ContainerVolume$
       }
@@ -974,8 +974,10 @@ PARTUPGRADE:NEEDS[ProfileDefault]
       RESOURCE
       {
         name = Food
-        amount = 1
-        maxAmount = 1
+        amount = 1.056
+        @amount *= 2
+        maxAmount = 1.056
+        @maxAmount *= 2
         @amount *= #$/ContainerVolume$
         @maxAmount *= #$/ContainerVolume$
       }
@@ -988,8 +990,10 @@ PARTUPGRADE:NEEDS[ProfileDefault]
       RESOURCE
       {
         name = Water
-        amount = 1
-        maxAmount = 1
+        amount = 0.528
+        @amount *= 4
+        maxAmount = 0.528
+        @maxAmount *= 4
         @amount *= #$/ContainerVolume$
         @maxAmount *= #$/ContainerVolume$
       }
@@ -1004,7 +1008,7 @@ PARTUPGRADE:NEEDS[ProfileDefault]
       {
         name = Waste
         amount = 0
-        maxAmount = 0.4946378
+        maxAmount = 1.1510426
         @amount *= #$/ContainerVolume$
         @maxAmount *= #$/ContainerVolume$
       }
@@ -1013,7 +1017,7 @@ PARTUPGRADE:NEEDS[ProfileDefault]
       {
         name = WasteWater
         amount = 0
-        maxAmount = 0.5053622
+        maxAmount = 0.443349
         @amount *= #$/ContainerVolume$
         @maxAmount *= #$/ContainerVolume$
       }
@@ -1027,7 +1031,8 @@ PARTUPGRADE:NEEDS[ProfileDefault]
       {
         name = Waste
         amount = 0
-        maxAmount = 1
+        maxAmount = 1.1510426
+		@maxAmount *= 2
         @amount *= #$/ContainerVolume$
         @maxAmount *= #$/ContainerVolume$
       }
@@ -1041,7 +1046,8 @@ PARTUPGRADE:NEEDS[ProfileDefault]
       {
         name = WasteWater
         amount = 0
-        maxAmount = 1
+        maxAmount = 0.443349
+		@maxAmount *= 4
         @amount *= #$/ContainerVolume$
         @maxAmount *= #$/ContainerVolume$
       }
@@ -1324,6 +1330,7 @@ PARTUPGRADE:NEEDS[ProfileDefault]
 
   !MODULE[ModuleGenerator] {}
   !MODULE[ModuleCoreHeat] {}
+  !MODULE[ModuleRadioisotopeGenerator] {}
 }
 
 

--- a/GameData/KerbalismConfig/Support/ReStock.cfg
+++ b/GameData/KerbalismConfig/Support/ReStock.cfg
@@ -1,0 +1,25 @@
+@PART[*]:HAS[@MODULE[ModuleGenerator]:HAS[@OUTPUT_RESOURCE[ElectricCharge]],@MODULE[ModuleRestockLaunchClamp]]:NEEDS[ReStock,ProfileDefault]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = ProcessController
+		resource = _ECGen
+		title = #KERBALISM_PowerSupply_title//Power supply
+		capacity = #$/MODULE[ModuleGenerator]:HAS[@OUTPUT_RESOURCE[ElectricCharge]]/OUTPUT_RESOURCE[ElectricCharge]/rate$
+		running = true
+		toggle = true
+	}
+
+	!MODULE[ModuleGenerator]:HAS[@OUTPUT_RESOURCE[ElectricCharge]] {}
+}
+
+@PART[*]:HAS[@MODULE[ProcessController]:HAS[#resource[?ECGen]],@MODULE[ModuleRestockLaunchClamp]]:NEEDS[ReStock]:AFTER[KerbalismDefault]
+{
+	// not working yet
+	// MODULE
+	// {
+		// name = PlannerController
+		// title = generator
+		// considered = false
+	// }
+}

--- a/GameData/KerbalismConfig/System/Planner.cfg
+++ b/GameData/KerbalismConfig/System/Planner.cfg
@@ -14,25 +14,27 @@
 }
 
 // only crewable launch towers like the FASA Launch Tower
-@PART[*]:HAS[@MODULE[ModuleGenerator],@MODULE[LaunchClamp],@MODULE[Habitat]]:AFTER[KerbalismDefault]
+@PART[*]:HAS[@MODULE[ProcessController]:HAS[#resource[_ECGen]],@MODULE[LaunchClamp],@MODULE[Habitat]]:AFTER[KerbalismDefault]
 {
-  MODULE
-  {
-	name = PlannerController
-	title = generator
-	considered = false
-  }
+  // not working yet
+  // MODULE
+  // {
+	// name = PlannerController
+	// title = generator
+	// considered = false
+  // }
 }
 
 // only "normal" launch clamps
-@PART[*]:HAS[@MODULE[ModuleGenerator],@MODULE[LaunchClamp],!MODULE[Habitat]]:AFTER[KerbalismDefault]
+@PART[*]:HAS[@MODULE[ProcessController]:HAS[#resource[_ECGen]],@MODULE[LaunchClamp],!MODULE[Habitat]]:AFTER[KerbalismDefault]
 {
-  MODULE
-  {
-	name = PlannerController
-	title = generator
-	considered = false
-  }
+  // not working yet
+  // MODULE
+  // {
+	// name = PlannerController
+	// title = generator
+	// considered = false
+  // }
 }
 
 @PART[*]:HAS[@MODULE[ModuleResourceConverter]]:FOR[KerbalismDefault]


### PR DESCRIPTION
To at least have something to bother with.
On launch clamps the PlannerController is pruned for now, but the EC gen is toggleable itself for QOL in VAB.