### PR TITLE
Avoid having unlimited Data storage in HardDrives

### DIFF
--- a/GameData/KerbalismConfig/System/ScienceRework/Patches-HardDrives.cfg
+++ b/GameData/KerbalismConfig/System/ScienceRework/Patches-HardDrives.cfg
@@ -488,3 +488,15 @@
 		}
 	}
 }
+
+// ============================================================================
+// Avoid having unlimited Data storage in HardDrives which should only hold
+// physical samples
+// ============================================================================
+@PART[*]:HAS[@MODULE[HardDrive]:HAS[#sampleCapacity,~dataCapacity[>0]]]:NEEDS[FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+	@MODULE[HardDrive]
+	{
+		%dataCapacity = 0
+	}
+}


### PR DESCRIPTION
Avoid having unlimited Data storage in HardDrives which should only hold physical samples, like for example the bluedog_GATV_MMDetector