### PR TITLE
Add missing Configure setups localization

### DIFF
--- a/src/Kerbalism/Lib.cs
+++ b/src/Kerbalism/Lib.cs
@@ -2438,6 +2438,13 @@ namespace KERBALISM
 			return reslib.Contains( name ) ? reslib[name] : null;
 		}
 
+		/// <summary>Returns resource localized display name</summary>
+		public static string GetResourceDisplayName(string name)
+		{
+			var res = GetDefinition(name);
+			return res == null ? "N.A. (" + name + ")" : res.displayName;
+		}
+
 		/// <summary> Returns name of propellant used on eva </summary>
 		public static string EvaPropellantName()
 		{

--- a/src/Kerbalism/Modules/Configure.cs
+++ b/src/Kerbalism/Modules/Configure.cs
@@ -458,11 +458,11 @@ namespace KERBALISM
 				if (setup.tech.Length > 0)
 				{
 					if (!org.ContainsKey(setup.tech)) org.Add(setup.tech, new List<string>());
-					org[setup.tech].Add(setup.name);
+					org[setup.tech].Add(setup.title);
 				}
 				else
 				{
-					specs.Add(Lib.BuildString("• <b>", setup.name, "</b>"));
+					specs.Add(Lib.BuildString("• <b>", setup.title, "</b>"));
 				}
 			}
 
@@ -471,7 +471,7 @@ namespace KERBALISM
 			{
 				// shortcuts
 				string tech_id = pair.Key;
-				List<string> setup_names = pair.Value;
+				List<string> setup_titles = pair.Value;
 
 				// get tech title
 				// note: non-stock technologies will return empty titles, so we use tech-id directly in that case
@@ -491,10 +491,10 @@ namespace KERBALISM
 				//specs.Add(string.Empty);
 				//specs.Add(Lib.BuildString("<color=#00ffff>", tech_title, ":</color>"));
 
-				// add setup names
-				foreach (string setup_name in setup_names)
+				// add setup titles
+				foreach (string setup_title in setup_titles)
 				{
-					specs.Add(Lib.BuildString("• <b>", setup_name, "</b>\n   at ", Lib.Color(tech_title, Lib.Kolor.Science)));
+					specs.Add(Lib.BuildString("• <b>", setup_title, "</b>\n   at ", Lib.Color(tech_title, Lib.Kolor.Science)));
 				}
 			}
 
@@ -584,11 +584,11 @@ namespace KERBALISM
 			// only allow reconfiguration if there are more setups than slots
 			if (unlocked.Count <= selected.Count)
 			{
-				p.AddSection(Lib.Ellipsis(setup.name, Styles.ScaleStringLength(70)), setup.desc);
+				p.AddSection(Lib.Ellipsis(setup.title, Styles.ScaleStringLength(70)), setup.desc);
 			}
 			else
 			{
-				p.AddSection(Lib.Ellipsis(setup.name, Styles.ScaleStringLength(70)), setup.desc, () => Change_setup(-1, selected_i, ref setup_i), () => Change_setup(1, selected_i, ref setup_i));
+				p.AddSection(Lib.Ellipsis(setup.title, Styles.ScaleStringLength(70)), setup.desc, () => Change_setup(-1, selected_i, ref setup_i), () => Change_setup(1, selected_i, ref setup_i));
 			}
 
 			// render details
@@ -641,6 +641,7 @@ namespace KERBALISM
 		{
 			// parse basic data
 			name = Lib.ConfigValue(node, "name", string.Empty);
+			title = Lib.ConfigValue(node, "title", name);
 			desc = Lib.ConfigValue(node, "desc", string.Empty);
 			tech = Lib.ConfigValue(node, "tech", string.Empty);
 			cost = Lib.ConfigValue(node, "cost", 0.0);
@@ -665,6 +666,7 @@ namespace KERBALISM
 		{
 			// load basic data
 			archive.Load(out name);
+			archive.Load(out title);
 			archive.Load(out desc);
 			archive.Load(out tech);
 			archive.Load(out cost);
@@ -686,6 +688,7 @@ namespace KERBALISM
 		{
 			// save basic data
 			archive.Save(name);
+			archive.Save(title);
 			archive.Save(desc);
 			archive.Save(tech);
 			archive.Save(cost);
@@ -752,7 +755,7 @@ namespace KERBALISM
 				foreach (ConfigureResource cr in visible_resources)
 				{
 					// add capacity info
-					details.Add(new Detail(cr.name, Lib.Parse.ToDouble(cr.maxAmount).ToString("F2")));
+					details.Add(new Detail(Lib.GetResourceDisplayName(cr.name), Lib.Parse.ToDouble(cr.maxAmount).ToString("F2")));
 				}
 			}
 
@@ -781,6 +784,7 @@ namespace KERBALISM
 		}
 
 		public string name;
+		public string title;
 		public string desc;
 		public string tech;
 		public double cost;

--- a/src/Kerbalism/Modules/Greenhouse.cs
+++ b/src/Kerbalism/Modules/Greenhouse.cs
@@ -387,7 +387,7 @@ namespace KERBALISM
 			growth = 0.0;
 
 			// show message
-			Message.Post(Lib.BuildString(Local.Greenhouse_msg_1.Format("<color=ffffff>" + vessel.vesselName + "</color> "), Local.Greenhouse_msg_2.Format("<color=ffffff>" + crop_size.ToString("F0") + " " + crop_resource + "</color>")));//"On <<1>>""harvest produced <<1>>", 
+			Message.Post(Lib.BuildString(Local.Greenhouse_msg_1.Format("<color=ffffff>" + vessel.vesselName + "</color> "), Local.Greenhouse_msg_2.Format("<color=ffffff>" + crop_size.ToString("F0") + " " + Lib.GetResourceDisplayName(crop_resource) + "</color>")));//"On <<1>>""harvest produced <<1>>", 
 
 			// record first harvest
 			if (!Lib.Landed(vessel)) DB.landmarks.space_harvest = true;
@@ -435,7 +435,7 @@ namespace KERBALISM
 		{
 			Specifics specs = new Specifics();
 
-			specs.Add(Local.Greenhouse_info1, Lib.HumanReadableAmount(crop_size, " " + crop_resource));//"Harvest size"
+			specs.Add(Local.Greenhouse_info1, Lib.HumanReadableAmount(crop_size, " " + Lib.GetResourceDisplayName(crop_resource)));//"Harvest size"
 			specs.Add(Local.Greenhouse_info2, Lib.HumanReadableDuration(1.0 / crop_rate));//"Harvest time"
 			specs.Add(Local.Greenhouse_info3, Lib.HumanReadableFlux(light_tolerance));//"Lighting tolerance"
 			if (pressure_tolerance > double.Epsilon) specs.Add(Local.Greenhouse_info4, Lib.HumanReadablePressure(Sim.PressureAtSeaLevel() * pressure_tolerance));//"Pressure tolerance"
@@ -461,13 +461,13 @@ namespace KERBALISM
 					dis_WACO2 = true;
 				}
 				else
-					specs.Add(input.name, Lib.BuildString("<color=#ffaa00>", Lib.HumanReadableRate(input.rate), "</color>"));
+					specs.Add(Lib.GetResourceDisplayName(input.name), Lib.BuildString("<color=#ffaa00>", Lib.HumanReadableRate(input.rate), "</color>"));
 			}
 			specs.Add(string.Empty);
 			specs.Add("<color=#00ffff>"+Local.Greenhouse_Byproducts +"</color>");//By-products
 			foreach (ModuleResource output in resHandler.outputResources)
 			{
-				specs.Add(output.name, Lib.BuildString("<color=#00ff00>", Lib.HumanReadableRate(output.rate), "</color>"));
+				specs.Add(Lib.GetResourceDisplayName(output.name), Lib.BuildString("<color=#00ff00>", Lib.HumanReadableRate(output.rate), "</color>"));
 			}
 			return specs;
 		}

--- a/src/Kerbalism/Modules/Harvester.cs
+++ b/src/Kerbalism/Modules/Harvester.cs
@@ -245,7 +245,7 @@ namespace KERBALISM
 		{
 			Specifics specs = new Specifics();
 			specs.Add(Local.Harvester_info1, ((HarvestTypes)type).ToString());//"type"
-			specs.Add(Local.Harvester_info2, resource);//"resource"
+			specs.Add(Local.Harvester_info2, Lib.GetResourceDisplayName(resource));//"resource"
 			if (min_abundance > double.Epsilon) specs.Add(Local.Harvester_info3, Lib.HumanReadablePerc(min_abundance, "F2"));//"min abundance"
 			if (type == 2 && min_pressure > double.Epsilon) specs.Add(Local.Harvester_info4, Lib.HumanReadablePressure(min_pressure));//"min pressure"
 			specs.Add(Local.Harvester_info5, Lib.HumanReadableRate(rate));//"extraction rate"

--- a/src/Kerbalism/Modules/ProcessController.cs
+++ b/src/Kerbalism/Modules/ProcessController.cs
@@ -155,13 +155,13 @@ namespace KERBALISM
 				foreach (KeyValuePair<string, double> pair in process.inputs)
 				{
 					if (!process.modifiers.Contains(pair.Key))
-						specs.Add(pair.Key, Lib.BuildString("<color=#ffaa00>", Lib.HumanReadableRate(pair.Value * capacity), "</color>"));
+						specs.Add(Lib.GetResourceDisplayName(pair.Key), Lib.BuildString(" <color=#ffaa00>", Lib.HumanReadableRate(pair.Value * capacity), "</color>"));
 					else
 						specs.Add(Local.ProcessController_info1, Lib.HumanReadableDuration(0.5 / pair.Value));//"Half-life"
 				}
 				foreach (KeyValuePair<string, double> pair in process.outputs)
 				{
-					specs.Add(pair.Key, Lib.BuildString("<color=#00ff00>", Lib.HumanReadableRate(pair.Value * capacity), "</color>"));
+					specs.Add(Lib.GetResourceDisplayName(pair.Key), Lib.BuildString(" <color=#00ff00>", Lib.HumanReadableRate(pair.Value * capacity), "</color>"));
 				}
 			}
 			return specs;


### PR DESCRIPTION
Since working with localization, I've found Kerbalism "Configure" PartModule to lack translatable content regarding:
- Resources (always displayed using "name" property instead of "displayName", as implemented for example by CRP)
- Setups "name" ConfigNode property, which in Configs isn't translatable since `name` property is used to identify the Setup block in following MM patches .

This PR covers the missing aspects introducing:
- A `GetResourceDisplayName` utility method which is used where Resource name should be displayed to end user, like Configure module and specifically ProcessController, Harvester and Greenhouse. The method doesn't fail if resource is missing, in order to handle invalid resources specified in mods.
- An additional `title` property available in `SETUP` ConfigNodes.  During loading if it's not present, it defaults to `name`, so it's totally backward compatible.

I'm not sure if resource display is covered everywhere in the code, I'm still playing in order to find blind spots. 