### PR TITLE
Small mod support changes and fixes

### DIFF
--- a/GameData/KerbalismConfig/Support/SSPX.cfg
+++ b/GameData/KerbalismConfig/Support/SSPX.cfg
@@ -1104,7 +1104,6 @@
 	}
 }
 
-// DangerNoodle: 
 @PART[sspx-cupola-greenhouse-125-1]:NEEDS[StationPartsExpansionRedux,ProfileDefault]:AFTER[KerbalismDefault]
 {
 	MODULE

--- a/GameData/KerbalismConfig/Support/SSPX.cfg
+++ b/GameData/KerbalismConfig/Support/SSPX.cfg
@@ -1104,6 +1104,7 @@
 	}
 }
 
+// DangerNoodle: 
 @PART[sspx-cupola-greenhouse-125-1]:NEEDS[StationPartsExpansionRedux,ProfileDefault]:AFTER[KerbalismDefault]
 {
 	MODULE
@@ -1111,40 +1112,40 @@
 		name = Greenhouse
 
 		crop_resource = Food								// name of resource produced by harvests
-		// 90 times less effective as kerbalism-greenhouse part. 
+		// 1/6 as effective as kerbalism-greenhouse part. 
 		// See https://forum.kerbalspaceprogram.com/index.php?/topic/172400-131145-kerbalism-v180/&page=32&tab=comments#comment-3446891 for details.
 
-		// This is a VERY small greenhouse, 90 times less crops than Kerbalism-greenhouse
-		crop_size = 0.30625									// 1/90 x kerbalism-greenhouse
-		crop_rate = 0.00000046296					 // 2 times regular growth speed
-		ec_rate = 0.0278												 // 1/90x"kerbalism-greenhouse"
-		light_tolerance = 400.0						 // minimum lighting flux required for growth, in W/m^2
+		// No independent growing possible. (Different watering and lighting needs for different grow stages). 
+		crop_size = 4.59375						// 1/3x kerbalism-greenhouse
+		crop_rate = 0.00000023148					// regular growth speed
+		ec_rate = 0.833							// 1/6x"kerbalism-greenhouse"
+		light_tolerance = 400.0						// minimum lighting flux required for growth, in W/m^2
 		pressure_tolerance = 0.1						// minimum pressure required for growth, in sea level atmospheres
 		radiation_tolerance = 0.000008333	 // maximum radiation allowed for growth in rad/s, considered after shielding is applied
 
 		INPUT_RESOURCE
 		{
 			name = Ammonia
-			rate = 0.00000106337							// 1/90x"kerbalism-greenhouse"
+			rate = 0.000015950520835						// 1/6x"kerbalism-greenhouse"
 		}
 
 		INPUT_RESOURCE
 		{
 			name = Water
-			rate = 0.0000000354							 // 1/90x"kerbalism-greenhouse"
+			rate = 0.0000005316835							 // 1/6x"kerbalism-greenhouse"
 		}
 
 		INPUT_RESOURCE
 		{
 			name = WasteAtmosphere						// Plants work on WasteAtmosphere and replace a scrubber, if not enough WasteAtmosphere exists then CO2 is used
-			rate = 0.0000138422							 // 1/90x"kerbalism-greenhouse"
+			rate = 0.0002076332917							 // 1/6x"kerbalism-greenhouse"
 		}
 
 		INPUT_RESOURCE
 		{
 			name = CarbonDioxide							// Kerbals don't provide enough WasteAtmosphere for their required food production. If excess WasteAtmosphere is
 																				// present then it will be used in place of CO2 injection
-			rate = 0.00000461407							// 1/90x"kerbalism-greenhouse"
+			rate = 0.000069211095835						// 1/6x"kerbalism-greenhouse"
 		}
 
 		// Note. if there is a deficiency in the amount of WasteAtmosphere needed then the missing amount of WasteAtmosphere will be added to the
@@ -1154,7 +1155,7 @@
 		OUTPUT_RESOURCE
 		{
 			name = Oxygen
-			rate = 0.0000191533							 // 1.1% of oxygen required by 1 crew member
+			rate = 0.00028729970835							 // 33.3334% of oxygen required by 1 crew member
 		}
 	}
 
@@ -1162,15 +1163,15 @@
 	RESOURCE
 	{
 		name = Ammonia
-		amount = 5												// 1/90x"kerbalism-greenhouse"
-		maxAmount = 5
+		amount = 45										// nearly 1/6x"kerbalism-greenhouse" since weird decimal nubers look weird on ressource tanks. would be ~90.6667
+		maxAmount = 45
 	}
 
 	RESOURCE
 	{
 		name = CarbonDioxide
-		amount = 50											 // 1/90x"kerbalism-greenhouse"
-		maxAmount = 50
+		amount = 750											 // 1/6x"kerbalism-greenhouse"
+		maxAmount = 750
 	}
 
 	// To support pressure control
@@ -1185,15 +1186,131 @@
 	RESOURCE
 	{
 		name = Nitrogen
-		amount = 110											// 1/90x"kerbalism-greenhouse" as it does not mess with crops
-		maxAmount = 110
+		amount = 2000											// reduced, because where would you fit such large tanks in such a small cupola?
+		maxAmount = 2000
 	}
 
 	RESOURCE
 	{
 		name = Water
-		amount = 0.12												 // 1/90x"kerbalism-greenhouse"
-		maxAmount = 0.12
+		amount = 2												 // nearly 1/6x"kerbalism-greenhouse" since weird decimal nubers look weird on ressource tanks. would be ~1.8334
+		maxAmount = 2
+	}
+}
+
+// The fish tank is different from all the others. I decided it gets 4x kerbalism greenhouse ("kg") / 2x 375-1 greenhouse food production.
+// It is now some sort of direct Waste-converter, as i imagine some fish species can use the biomatter contained in waste more efficiently than just extracting the wastes nh3
+// Uses 2 Kerbals worth of Waste as fish-fodder, plus algae from integrated tanks that are as effective as 1x "kg" in both input and output
+// The fish however only consume/produce 1.75 Kerbals worth of co2/o2 while ingesting 2 Kerbals of food per day (not actual biomass of a Kerbal, the amount of food eaten by one per day)
+// I suspect growing lifeforms exhale a lower percentage of their ingested carbon as co2, than fully grown individuals of their kind,
+// because at least some of that carbon  needs to be integrated into their bodies for growing.
+
+@PART[sspx-aquaculture-375-1]:NEEDS[StationPartsExpansionRedux,ProfileDefault]:AFTER[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Greenhouse
+
+		crop_resource = Food								// name of resource produced by harvests
+		// Twice as effective as kerbalism-greenhouse part. 
+		// See https://forum.kerbalspaceprogram.com/index.php?/topic/172400-131145-kerbalism-v180/&page=32&tab=comments#comment-3446891 for details.
+
+		// Aquaculture module; produces food for 2 kerbals, co2 for 0.416667 (included algae tanks i guess) 
+		// consumes waste of 2 kerbals + ammonia of 1x kerbalism-greenhouse (for algae), o2 of 0.75 kerbals, some water and ec
+		// somewhat higher food per ammonia ratio than traditional greenhouses, 0.0957 food/nh3 instead of 0.0667 food/nh3
+
+		crop_size = 58.7087						// slightly faster than 1x kerbalism-greenhouse to match changed growth speed, would be 234.8312 if treated as one tank
+		crop_rate = 0.0000004347					// way faster growth speed, would be 0.000000108675 if treated as one tank, one kerbin year growth cycle, 1/4 bc 4 tanks
+		ec_rate = 20							// 8x"kerbalism-greenhouse" bc of more expensive pumping, filtration, and temp regulation needs
+		light_tolerance = 400.0						// minimum lighting flux required for growth, in W/m^2
+		pressure_tolerance = 0.1					// minimum pressure required for growth, in sea level atmospheres
+		radiation_tolerance = 0.000008333	 			// maximum radiation allowed for growth in rad/s, considered after shielding is applied
+
+		INPUT_RESOURCE
+		{
+			name = Waste
+			rate = 0.000009104939					// 2x kerbal
+		}
+
+		INPUT_RESOURCE
+		{
+			name = Ammonia
+			rate = 0.000095703125					// 1x"kerbalism-greenhouse"
+		}
+
+		INPUT_RESOURCE
+		{
+			name = Water
+			rate = 0.00000382812					// 1.2x"kerbalism-greenhouse". 1x for Photosynthesis of algae. 0.2x for fish. Water is filtered so less water consumed. I dont know how much water fish actually drink, and dont pee out again
+		}
+
+//		INPUT_RESOURCE
+//		{
+//			name = Atmosphere					// Fish work on Atmosphere, if not enough Atmosphere exists then O2 is used, 
+										// does this work? no it doesnt, and i dont know how to make it work. System seems to only work with WasteAtmosphere/CO2
+//			rate = 0.001868699625					// 1.5x"kerbalism-greenhouse"
+//		}
+
+		INPUT_RESOURCE
+		{
+			name = Oxygen						// (in theory) If excess Atmosphere is present then it will be used in place of O2 injection
+			rate = 0.0012928486875					// 0.75x"kerbalism-greenhouse (kg)" Accounting for 1x "kg" production from algae tanks and 1.75x "kg" consumption from fish
+		}
+
+		// (again, in theory) Note. if there is a deficiency in the amount of Atmosphere needed then the missing amount of Atmosphere will be added to the
+		// Oxygen input and Vies Versa if not enough Oxygen is present and there is extra Atmosphere.
+		// If there is not enough resources then the fish will suffer.
+
+		OUTPUT_RESOURCE
+		{
+			name = CarbonDioxide					// 1 kerbalism greenhouse co2 equivalent input per second: 0.001661066325
+			rate = 0.0005190832265625				// 41.6667% of CarbonDioxide produced by 1 crew member, or 31.25% "kg". Algae consume 1x "kg"/1.3334x Kerbal worth of co2. Fish produce 1.75 Kerbals / 1.3125x "kg" co2
+		}
+	}
+
+	// Concider those nice IVA tanks and closets for increasing current resource capacity. I won't touch em for now.
+	RESOURCE
+	{
+		name = Ammonia
+		amount = 544							// 2x"kerbalism-greenhouse"
+		maxAmount = 544
+	}
+
+	RESOURCE
+	{
+		name = Oxygen
+		amount = 9000							// 2x"kerbalism-greenhouse"
+		maxAmount = 9000
+	}
+
+	RESOURCE
+	{
+		name = CarbonDioxide
+		amount = 0							// 2x"kerbalism-greenhouse"
+		maxAmount = 9000
+	}
+
+	// To support pressure control
+	@MODULE[Configure]
+	{
+		@SETUP[Pressure?Control]
+		{
+		!RESOURCE[Nitrogen] {}
+		}
+	}
+
+	RESOURCE
+	{
+		name = Nitrogen
+		amount = 10000							// 1x"kerbalism-greenhouse" as it does not mess with crops
+		maxAmount = 10000
+	}
+
+	RESOURCE
+	{
+		name = Water
+		amount = 22							// 2x"kerbalism-greenhouse"
+		maxAmount = 22
 	}
 }
 // ============================================================================

--- a/GameData/KerbalismConfig/Support/SSPX_Science.cfg
+++ b/GameData/KerbalismConfig/Support/SSPX_Science.cfg
@@ -324,3 +324,27 @@
 		@sampleCapacity = #$@KERBALISM_HDD_SIZES/SSPX/AstrolabeObservation/samples$
 	}
 }
+
+// =========================================================================
+// Changing lab analysis speed of some parts; added by DangerNoodle
+// =========================================================================
+
+// Larger Labs should analyse Samples faster/more samples simultaneously, right?
+
+@PART[sspx-lab-375-1]:NEEDS[FeatureScience,StationPartsExpansionRedux]:AFTER[KerbalismDefault]		
+{
+	@MODULE[Laboratory]
+	{
+		@analysis_rate = 0.01	// doubled in relation to stock lab, as 1st more kerbals, and 2nd more modern equipment
+		@ec_rate = 2.0		// doubled too
+	}
+}
+
+@PART[sspx-lab-5-1]:NEEDS[FeatureScience,StationPartsExpansionRedux]:AFTER[KerbalismDefault]		
+{
+	@MODULE[Laboratory]
+	{
+		@analysis_rate = 0.02	// quadrupled in relation to stock lab, as 1st more kerbals, and 2nd more modern equipment
+		@ec_rate = 4.0		// doubled too
+	}
+}

--- a/GameData/KerbalismConfig/Support/UniversalStorage2.cfg
+++ b/GameData/KerbalismConfig/Support/UniversalStorage2.cfg
@@ -192,6 +192,19 @@
     capacity = 18 // part is 0.24t, ECLSS is 0.04 for capacity = 3
     running = false
   }
+}
 
+@PART[USSabatier]:NEEDS[ProfileDefault]:FOR[KerbalismDefault]
+{
+  !MODULE[ModuleResourceConverter] {}
 
+  MODULE
+  {
+    name = ProcessController
+    resource = _Sabatier
+    title = #KERBALISM_SabatierProcess_title //Sabatier process
+    capacity = 13.2 // part is 0.528t, ECLSS is 0.04 for capacity = 1
+    valve_i = 2 // workaround until we have a better way to deal with dump valves
+    running = false
+  }
 }

--- a/GameData/KerbalismConfig/System/ScienceRework/Patches-Experiments.cfg
+++ b/GameData/KerbalismConfig/System/ScienceRework/Patches-Experiments.cfg
@@ -385,7 +385,7 @@
 		ec_rate = 1.0
 	}
 }
-@PART[Large_Crewed_Lab]:HAS[@MODULE[ModuleScienceLab]]:NEEDS[FeatureScience]:FIRST
+@PART[*]:HAS[@MODULE[ModuleScienceLab]]:NEEDS[FeatureScience]:FIRST // DangerNoodle; changed from PART[Large_Crewed_Lab] to PART[*] for easy mod support
 {
 	MODULE
 	{

--- a/GameData/KerbalismConfig/System/ScienceRework/Patches-HardDrives.cfg
+++ b/GameData/KerbalismConfig/System/ScienceRework/Patches-HardDrives.cfg
@@ -25,7 +25,7 @@
 // ============================================================================
 // Adding HardDrive module for snowflakes so they can get patched.
 // ============================================================================
-@PART[*]:HAS[@MODULE[ModuleScienceLab]]:NEEDS[FeatureScience]
+@PART[*]:HAS[@MODULE[Laboratory]]:NEEDS[FeatureScience] // DangerNoodle; ModuleScienceLab got removed two files above, every part has Laboratory module instead. Replaced ModuleScienceLab with Laboratory
 {
 	MODULE
 	{


### PR DESCRIPTION
(Basicially a copy of my forum post)

I would like to share some changes/additions I've made to a few .cfg files. These include:

**SSPX.cfg:**
- Changed cupola-greenhouse-125-1 from 1/90 to 1/6 of kerbalism greenhouse
- Added custom greenhouse module for aquaculture-375-1

**SSPX_Science.cfg:**
- Added a patch to change the analysis speed of some labs

**UniversalStorage2.cfg:**
- Added support for the US2 sabatier reactor part, scaled accordingly

**Patches-Experiments.cfg:**
- Changed a line to enable kerbalism to add lab experiments to all labs and not just the stock lab

**Patches-HardDrives.cfg:**
- Changed a line to enable the patch to correctly add hard drives to labs

 

**Detailed explanation:**

**SSPX.cfg:**
The cupola greenhouse has 1/12 as many individual plants as the greenhouse-375-1, wich is 2x as good as the default kerbalism greenhouse.

The fish tank is different from all the others. I decided it gets 4x kerbalism greenhouse ("kg") / 2x 375-1 greenhouse food production.
It is now some sort of direct Waste-converter, as i imagine some fish species can use the biomatter contained in waste more efficiently than just extracting the wastes nh3
Uses 2 Kerbals worth of Waste as fish-fodder, plus algae from integrated tanks that are as effective as 1x "kg" in both input and output
The fish however only consume/produce 1.75 Kerbals worth of co2/o2 while ingesting 2 Kerbals of food per day (not actual biomass of a Kerbal, the amount of food eaten by one per day)
I suspect growing lifeforms exhale a lower percentage of their ingested carbon as co2, than fully grown individuals of their kind,
because at least some of that carbon  needs to be integrated into their bodies for growing.

**SSPX_Science.cfg:**
The large labs can fit more scientists, and house more and also probably more modern equipment, so they should be realistically abe to analyse samples faster.

**UniversalStorage2.cfg:**
There was no config for the sabatier reactor so I added one that is scaled in the same vein as the other parts, using its mass in relation to the kerbalism ECLSS

**Patches-Experiments.cfg:**
The line in question effectively adds lab experiments to parts with a kerbalism laboratory module, but only targets the stock lab for whatever reason, despite other lab related patches targeting all parts with lab modules
Now all modded labs too get lab experiments

**Patches-HardDrives.cfg:**
The line in question adds a hard drive modules to all parts with a stock lab module, but that stock lab module got removed two files above.
I've changed the filter module to the kerbalism lab module instead.