### PR TITLE
Workaround broken "dump=true" setting

### DIFF
--- a/GameData/KerbalismConfig/Profiles/Default.cfg
+++ b/GameData/KerbalismConfig/Profiles/Default.cfg
@@ -537,7 +537,7 @@ PARTUPGRADE:NEEDS[ProfileDefault]
     title = #KERBALISM_Scrubber_title//Scrubber
     capacity = #$/CrewCapacity$
     running = true
-	valve_i = 1
+    valve_i = 1
   }
 
   MODULE

--- a/GameData/KerbalismConfig/Profiles/Default.cfg
+++ b/GameData/KerbalismConfig/Profiles/Default.cfg
@@ -212,7 +212,7 @@ Profile
     input = ElectricCharge@0.025
     input = WasteAtmosphere@0.00124579975
     output = CarbonDioxide@0.00124579975
-    dump = true
+    dump_valve = CarbonDioxide
   }
 
   // convention: 1 capacity = enough to compensate for leaks in 70 m² surface area (a cube of 40 m³ volume, edge length of 3.42 m) per crew member
@@ -469,7 +469,7 @@ Profile
     input = Oxygen@0.002
     output = CarbonDioxide@0.001987945992
     cures = radiation@0.000005555554 // 0.02 rad/h
-    dump = true
+    dump_valve = CarbonDioxide
   }
 
   Process
@@ -537,6 +537,7 @@ PARTUPGRADE:NEEDS[ProfileDefault]
     title = #KERBALISM_Scrubber_title//Scrubber
     capacity = #$/CrewCapacity$
     running = true
+	valve_i = 1
   }
 
   MODULE


### PR DESCRIPTION
Dump=true was broken in the recent dump fixes.  Rather than try to figure out why, you can address it config side, as shown here.  Up to you which fix you use.