### PR TITLE
Make WasteProcessor able to dump excess Ammonia

### DIFF
--- a/GameData/KerbalismConfig/Profiles/Default.cfg
+++ b/GameData/KerbalismConfig/Profiles/Default.cfg
@@ -265,6 +265,7 @@ Profile
     // Feces is considered to the dominant source of Waste
     // Waste is 975.3 times more dense than Ammonia
     output = Ammonia@0.000031083125
+    dump_valve = Ammonia
   }
 
   // convention: 1 capacity = enough to compress output of 1 crew member


### PR DESCRIPTION
Fixes #859 . Currently WasteProcessor cannot dump Ammonia and stops when storage is full. Adds the option to vent Ammonia.