### PR TITLE
Improve analytic sun exposure

### DIFF
--- a/src/Kerbalism/Database/VesselData.cs
+++ b/src/Kerbalism/Database/VesselData.cs
@@ -283,7 +283,7 @@ namespace KERBALISM
 						if (Settings.UseSamplingSunFactor)
 							// sampling estimation of the portion of orbit that is in sunlight
 							// until we will calculate again
-							sunInfo.sunlightFactor = Sim.SampleSunFactor(v, elapsedSeconds);
+							sunInfo.sunlightFactor = Sim.SampleSunFactor(v, elapsedSeconds, sunData.body);
 
 						else
 							// analytical estimation of the portion of orbit that was in sunlight.

--- a/src/Kerbalism/Database/VesselData.cs
+++ b/src/Kerbalism/Database/VesselData.cs
@@ -279,8 +279,6 @@ namespace KERBALISM
 					{
 						// get sun direction and distance
 						Lib.DirectionAndDistance(vesselPosition, sunInfo.sunData.body, out sunInfo.direction, out sunInfo.distance);
-						// analytical estimation of the portion of orbit that was in sunlight.
-						// it has some limitations, see the comments on Sim.ShadowPeriod
 
 						if (Settings.UseSamplingSunFactor)
 							// sampling estimation of the portion of orbit that is in sunlight
@@ -289,8 +287,8 @@ namespace KERBALISM
 
 						else
 							// analytical estimation of the portion of orbit that was in sunlight.
-							// it has some limitations, see the comments on Sim.ShadowPeriod
-							sunInfo.sunlightFactor = 1.0 - Sim.ShadowPeriod(v) / Sim.OrbitalPeriod(v);
+							// it has some limitations, see the comments on Sim.EclipseFraction
+							sunInfo.sunlightFactor = 1.0 - Sim.EclipseFraction(v, sunData.body, sunInfo.direction);
 
 
 						// get atmospheric absorbtion


### PR DESCRIPTION
This PR substantially rewrites both the analytic and the sampling methods of calculating sun exposure for vessels in analytic warp rates.

* On the analytic side, we use one of two methods. First, for low-eccentricity orbit, we use a method from a scientific paper ( https://commons.erau.edu/cgi/viewcontent.cgi?article=1412&context=ijaaa ); the paper is for LEO but it produces reasonable results at high altitude as well. Second, for high-eccentricity orbits, we use a bespoke method. It ignores shadow on objects on escape since those have incredibly limited shadow periods with respect to their orbit tracks, but for closed orbits it calculates the portion of the orbit (given beta angle and angle from the periapsis->body vector vs. the solar vector) that is eclipsed, with some fudging based on beta angle to avoid having to do considerable work regarding inclination and argument of periapsis.
* On the sampling side, we make use of a body cache and a fast method of calculating relative orbital position at UT, which allows us to speed up the sampling considerably. We also fix a bug where 

In both cases landed vessels have their exposure calculated more deeply than before; in the analytic case, we check for tidally locked bodies, and in the sampling case we calculate position and continue to use analytic raycasting.