### PR TITLE
Add support for SI units

### DIFF
--- a/GameData/KerbalismConfig/Settings.cfg
+++ b/GameData/KerbalismConfig/Settings.cfg
@@ -49,6 +49,13 @@ Kerbalism
   ExternRadiation = 0.04              // cosmic background radiation in rad/h. note: this will be affected by magnetospheres of kerbin and sun
   StormRadiation = 5.0                // default storm radiation in rad/h, will be affected by solar cycle. can be changed in game preferences
   //RadiationInSievert = true         // use Sievert (Sv) iso. rad as radiation unit
+  //UseSIUnits = true                 // use SI units when available when pretty-printing, via adding unit info to RESOURCE_DEFINITIONs
+    // you can add:
+    // amountUnit - the string to use as the unit for amounts
+    // rateUnit (if unspecified, amountUnit will be used, and /s appended if useRatePostfix isn't set to false
+    // multiplierToUnit - defaults to 1. Used if the resource amount and the unit don't match (e.g. Megajoules being MJ not J)
+    // useHuman - if specified will use the rate and amount units but not SI (i.e. will display in human-readable rate, and the total without milli/kilo/etc for amounts). When this is specified, useRatePostfix is treated as false regardless of its value
+    // Note: a resource that doesn't have at least amountUnit specified won't be valid and won't be used by UseSIUnits
 
   // installation sanity check settings
   CheckForCRP = true

--- a/src/Kerbalism/Lib.cs
+++ b/src/Kerbalism/Lib.cs
@@ -274,6 +274,9 @@ namespace KERBALISM
 		{
 			get
 			{
+				if (!GameSettings.KERBIN_TIME)
+					return 24.0;
+
 				if (hoursInDay == -1.0)
 				{
 					if (FlightGlobals.ready || IsEditor())
@@ -283,7 +286,7 @@ namespace KERBALISM
 					}
 					else
 					{
-						return GameSettings.KERBIN_TIME ? 6.0 : 24.0;
+						return 6.0;
 					}
 
 				}
@@ -297,6 +300,9 @@ namespace KERBALISM
 		{
 			get
 			{
+				if (!GameSettings.KERBIN_TIME)
+					return 365.0;
+
 				if (daysInYear == -1.0)
 				{
 					if (FlightGlobals.ready || IsEditor())
@@ -306,7 +312,7 @@ namespace KERBALISM
 					}
 					else
 					{
-						return GameSettings.KERBIN_TIME ? 426.0 : 365.0;
+						return 426.0;
 					}
 				}
 				return daysInYear;

--- a/src/Kerbalism/Lib.cs
+++ b/src/Kerbalism/Lib.cs
@@ -1004,12 +1004,14 @@ namespace KERBALISM
 
 		public const double bitsPerMB = 1000.0 * 1000.0 * 8.0;
 
+		public const double bPerMB = 1000.0 * 1000.0 * 8;
 		public const double BPerMB = 1000.0 * 1000.0;
 		public const double kBPerMB = 1000.0;
 		public const double GBPerMB = 1.0 / 1000.0;
 		public const double TBPerMB = 1.0 / (1000.0 * 1000.0);
 
-		public const double MBPerBTenth = 1.0 / (1000.0 * 1000.0 * 10.0);
+		public const double MBPerBitTenth = 1.0 / (1000.0 * 1000.0 * 10.0 * 8.0);
+		public const double MBPerB = 1.0 / (1000.0 * 1000.0);
 		public const double MBPerkB = 1.0 / 1000.0;
 		public const double MBPerGB = 1000.0;
 		public const double MBPerTB = 1000.0 * 1000.0;
@@ -1017,8 +1019,10 @@ namespace KERBALISM
 		///<summary> Format data size, the size parameter is in MB (megabytes) </summary>
 		public static string HumanReadableDataSize(double size)
 		{
-			if (size < MBPerBTenth)  // min size is 0.1 byte
+			if (size < MBPerBitTenth)  // min size is 0.1 bit
 				return Local.Generic_NONE;//"none"
+			if (size < MBPerB)
+				return (size * bPerMB).ToString("0.0 b");
 			if (size < MBPerkB)
 				return (size * BPerMB).ToString("0.0 B");
 			if (size < 1.0)
@@ -1034,8 +1038,10 @@ namespace KERBALISM
 		///<summary> Format data rate, the rate parameter is in MB/s </summary>
 		public static string HumanReadableDataRate(double rate)
 		{
-			if (rate < MBPerBTenth)  // min rate is 0.1 byte/s
+			if (rate < MBPerBitTenth)  // min rate is 0.1 bit/s
 				return Local.Generic_NONE;//"none"
+			if (rate < MBPerB)
+				return (rate * bPerMB).ToString("0.0 b/s");
 			if (rate < MBPerkB)
 				return (rate * BPerMB).ToString("0.0 B/s");
 			if (rate < 1.0)

--- a/src/Kerbalism/Modules/AntennaDataTransmitterRemoteTech.cs
+++ b/src/Kerbalism/Modules/AntennaDataTransmitterRemoteTech.cs
@@ -56,8 +56,8 @@ namespace KERBALISM
 						double transmissionEnergyCost = this.packetResourceCost * dataRate;
 						double idleEnergyCost = this.energyCost;
 
-						specs.Add(Local.DataTransmitter_ECidle, Lib.Color(Lib.HumanReadableRate(idleEnergyCost), Lib.Kolor.Orange));//"EC (idle)"
-						specs.Add(Local.DataTransmitter_ECTX + " Max", Lib.Color(Lib.HumanReadableRate(transmissionEnergyCost + idleEnergyCost), Lib.Kolor.Orange));//"EC (transmitting)"
+						specs.Add(Local.DataTransmitter_ECidle, Lib.Color(Lib.HumanOrSIRate(idleEnergyCost, Lib.ECResID), Lib.Kolor.Orange));//"EC (idle)"
+						specs.Add(Local.DataTransmitter_ECTX + " Max", Lib.Color(Lib.HumanOrSIRate(transmissionEnergyCost + idleEnergyCost, Lib.ECResID), Lib.Kolor.Orange));//"EC (transmitting)"
 						specs.Add("");
 						specs.Add(Local.DataTransmitter_Maxspeed, Lib.HumanReadableDataRate(dataRate));//"Max. speed"
 						break;

--- a/src/Kerbalism/Modules/Emitter.cs
+++ b/src/Kerbalism/Modules/Emitter.cs
@@ -214,7 +214,13 @@ namespace KERBALISM
 		{
 			Specifics specs = new Specifics();
 			specs.Add(radiation >= 0.0 ? Local.Emitter_Emitted : Local.Emitter_ActiveShielding, Lib.HumanReadableRadiation(Math.Abs(radiation)));
-			if (ec_rate > double.Epsilon) specs.Add("EC/s", Lib.HumanReadableRate(ec_rate));
+			if (ec_rate > double.Epsilon)
+			{
+				if (Settings.UseSIUnits)
+					specs.Add(Local.Deploy_actualCost, Lib.SIRate(ec_rate, Lib.ECResID));
+				else
+					specs.Add("EC/s", Lib.HumanReadableRate(ec_rate));
+			}
 			return specs;
 		}
 

--- a/src/Kerbalism/Modules/Experiment.cs
+++ b/src/Kerbalism/Modules/Experiment.cs
@@ -1114,9 +1114,9 @@ namespace KERBALISM
 			specs.Add(string.Empty);
 			specs.Add(Lib.Color(Local.Module_Experiment_Specifics_info8, Lib.Kolor.Cyan, true));//"Needs:"
 
-			specs.Add(Local.Module_Experiment_Specifics_info9, Lib.HumanReadableRate(prefab.ec_rate));//"EC"
+			specs.Add(Local.Module_Experiment_Specifics_info9, Lib.HumanOrSIRate(prefab.ec_rate, Lib.ECResID));//"EC"
 			foreach (var p in ParseResources(prefab.resources))
-				specs.Add(p.Key, Lib.HumanReadableRate(p.Value));
+				specs.Add(p.Key, Lib.HumanOrSIRate(p.Value, p.Key.GetHashCode()));
 
 			if (prefab.crew_prepare.Length > 0)
 			{

--- a/src/Kerbalism/Modules/GravityRing.cs
+++ b/src/Kerbalism/Modules/GravityRing.cs
@@ -289,7 +289,10 @@ namespace KERBALISM
 		{
 			Specifics specs = new Specifics();
 			specs.Add(Local.GravityRing_info1, "firm-ground");//"bonus"
-			specs.Add("EC/s", Lib.HumanReadableRate(ec_rate));
+			if (Settings.UseSIUnits)
+				specs.Add(Local.Deploy_actualCost, Lib.SIRate(ec_rate, Lib.ECResID));
+			else
+				specs.Add("EC/s", Lib.HumanReadableRate(ec_rate));
 			specs.Add(Local.GravityRing_info2, deploy.Length > 0 ? Local.GravityRing_yes : Local.GravityRing_no);//"deployable""yes""no"
 			return specs;
 		}

--- a/src/Kerbalism/Modules/Greenhouse.cs
+++ b/src/Kerbalism/Modules/Greenhouse.cs
@@ -443,7 +443,7 @@ namespace KERBALISM
 			specs.Add(Local.Greenhouse_info3, Lib.HumanReadableFlux(light_tolerance));//"Lighting tolerance"
 			if (pressure_tolerance > double.Epsilon) specs.Add(Local.Greenhouse_info4, Lib.HumanReadablePressure(Sim.PressureAtSeaLevel() * pressure_tolerance));//"Pressure tolerance"
 			if (radiation_tolerance > double.Epsilon) specs.Add(Local.Greenhouse_info5, Lib.HumanReadableRadiation(radiation_tolerance));//"Radiation tolerance"
-			specs.Add(Local.Greenhouse_info6, Lib.HumanReadableRate(ec_rate));//"Lamps EC rate"
+			specs.Add(Local.Greenhouse_info6, Lib.HumanOrSIRate(ec_rate, Lib.ECResID));//"Lamps EC rate"
 			specs.Add(string.Empty);
 			specs.Add("<color=#00ffff>" + Local.Greenhouse_info7 + "</color>");//Required resources
 
@@ -459,18 +459,18 @@ namespace KERBALISM
 					ModuleResource sec;
 					if (input.name == "WasteAtmosphere") sec = resHandler.inputResources.Find(x => x.name.Contains("CarbonDioxide"));
 					else sec = resHandler.inputResources.Find(x => x.name.Contains("WasteAtmosphere"));
-					specs.Add(Local.Greenhouse_CarbonDioxide, Lib.BuildString("<color=#ffaa00>", Lib.HumanReadableRate(input.rate + sec.rate), "</color>"));//"CarbonDioxide"
+					specs.Add(Local.Greenhouse_CarbonDioxide, Lib.BuildString("<color=#ffaa00>", Lib.HumanOrSIRate(input.rate + sec.rate, "CarbonDioxide".GetHashCode()), " </color>"));//"CarbonDioxide"
 					specs.Add(Local.Greenhouse_CarbonDioxide_desc);//"Crops can also use the CO2 in the atmosphere without a scrubber."
 					dis_WACO2 = true;
 				}
 				else
-					specs.Add(Lib.GetResourceDisplayName(input.name), Lib.BuildString("<color=#ffaa00>", Lib.HumanReadableRate(input.rate), "</color>"));
+					specs.Add(Lib.GetResourceDisplayName(input.name), Lib.BuildString("<color=#ffaa00>", Lib.HumanOrSIRate(input.rate, input.id), "</color>"));
 			}
 			specs.Add(string.Empty);
 			specs.Add("<color=#00ffff>"+Local.Greenhouse_Byproducts +"</color>");//By-products
 			foreach (ModuleResource output in resHandler.outputResources)
 			{
-				specs.Add(Lib.GetResourceDisplayName(output.name), Lib.BuildString("<color=#00ff00>", Lib.HumanReadableRate(output.rate), "</color>"));
+				specs.Add(Lib.GetResourceDisplayName(output.name), Lib.BuildString("<color=#00ff00>", Lib.HumanOrSIRate(output.rate, output.id), "</color>"));
 			}
 			return specs;
 		}

--- a/src/Kerbalism/Modules/Harvester.cs
+++ b/src/Kerbalism/Modules/Harvester.cs
@@ -251,9 +251,10 @@ namespace KERBALISM
 			specs.Add(Local.Harvester_info2, Lib.GetResourceDisplayName(resource));//"resource"
 			if (min_abundance > double.Epsilon) specs.Add(Local.Harvester_info3, Lib.HumanReadablePerc(min_abundance, "F2"));//"min abundance"
 			if (type == 2 && min_pressure > double.Epsilon) specs.Add(Local.Harvester_info4, Lib.HumanReadablePressure(min_pressure));//"min pressure"
+			// NOTE: we aren't using SI here.
 			specs.Add(Local.Harvester_info5, Lib.HumanReadableRate(rate));//"extraction rate"
 			specs.Add(Local.Harvester_info6, Lib.HumanReadablePerc(abundance_rate, "F2"));//"at abundance"
-			if (ec_rate > double.Epsilon) specs.Add(Local.Harvester_info7, Lib.HumanReadableRate(ec_rate));//"ec consumption"
+			if (ec_rate > double.Epsilon) specs.Add(Local.Harvester_info7, Lib.HumanOrSIRate(ec_rate, Lib.ECResID));//"ec consumption"
 			return specs;
 		}
 

--- a/src/Kerbalism/Modules/KebalismSentinel.cs
+++ b/src/Kerbalism/Modules/KebalismSentinel.cs
@@ -160,7 +160,7 @@ namespace KERBALISM
 		{
 			Specifics specs = new Specifics();
 			specs.Add(Lib.Color(Local.Module_Experiment_Specifics_info8, Lib.Kolor.Cyan, true));//"Needs:"
-			if (ec_rate > 0.0) specs.Add(Local.Module_Experiment_Specifics_info9, Lib.HumanReadableRate(ec_rate));//"EC"
+			if (ec_rate > 0.0) specs.Add(Local.Module_Experiment_Specifics_info9, Lib.HumanOrSIRate(ec_rate, Lib.ECResID));//"EC"
 			if (comms_rate > 0.0) specs.Add(Local.Module_Experiment_Specifics_info2, Lib.HumanReadableDataRate(comms_rate)); // "Data rate"
 
 			return specs.Info();

--- a/src/Kerbalism/Modules/Laboratory.cs
+++ b/src/Kerbalism/Modules/Laboratory.cs
@@ -222,7 +222,7 @@ namespace KERBALISM
 			Specifics specs = new Specifics();
 			specs.Add(Local.Laboratory_Researcher, new CrewSpecs(researcher).Info());
 			if (cleaner) specs.Add(Local.Laboratory_CanClean);
-			specs.Add(Local.Laboratory_ECrate, Lib.HumanReadableRate(ec_rate));
+			specs.Add(Local.Laboratory_ECrate, Lib.HumanOrSIRate(ec_rate, Lib.ECResID));
 			specs.Add(Local.Laboratory_rate, Lib.HumanReadableDataRate(analysis_rate));
 			return specs;
 		}

--- a/src/Kerbalism/Modules/ProcessController.cs
+++ b/src/Kerbalism/Modules/ProcessController.cs
@@ -199,13 +199,13 @@ namespace KERBALISM
 				foreach (KeyValuePair<string, double> pair in process.inputs)
 				{
 					if (!process.modifiers.Contains(pair.Key))
-						specs.Add(Lib.GetResourceDisplayName(pair.Key), Lib.BuildString(" <color=#ffaa00>", Lib.HumanReadableRate(pair.Value * capacity), "</color>"));
+						specs.Add(Lib.GetResourceDisplayName(pair.Key), Lib.BuildString(" <color=#ffaa00>", Lib.HumanOrSIRate(pair.Value * capacity, pair.Key.GetHashCode()), "</color>"));
 					else
 						specs.Add(Local.ProcessController_info1, Lib.HumanReadableDuration(0.5 / pair.Value));//"Half-life"
 				}
 				foreach (KeyValuePair<string, double> pair in process.outputs)
 				{
-					specs.Add(Lib.GetResourceDisplayName(pair.Key), Lib.BuildString(" <color=#00ff00>", Lib.HumanReadableRate(pair.Value * capacity), "</color>"));
+					specs.Add(Lib.GetResourceDisplayName(pair.Key), Lib.BuildString(" <color=#00ff00>", Lib.HumanOrSIRate(pair.Value * capacity, pair.Key.GetHashCode()), "</color>"));
 				}
 			}
 			return specs;

--- a/src/Kerbalism/Modules/SolarPanelFixer.cs
+++ b/src/Kerbalism/Modules/SolarPanelFixer.cs
@@ -32,9 +32,10 @@ namespace KERBALISM
 	public class SolarPanelFixer : PartModule
 	{
 		#region Declarations
-		/// <summary>Unit to show in the UI, this is the only configurable field for this module</summary>
+		/// <summary>Unit to show in the UI, this is the only configurable field for this module. Default is actually set in OnLoad and if a rateUnit is set for ElectricCharge and this is not specified, the rateUnit will be used instead.</summary>
 		[KSPField]
-		public string EcUIUnit = "EC/s";
+		public string EcUIUnit = string.Empty;
+		public bool hasRUI = false; // are we using a ResourceUnitInfo?
 
 		/// <summary>Main PAW info label</summary>
 		[KSPField(guiActive = true, guiActiveEditor = false, guiName = "#KERBALISM_SolarPanelFixer_Solarpanel")]//Solar panel
@@ -159,7 +160,18 @@ namespace KERBALISM
 		public override void OnLoad(ConfigNode node)
 		{
 			if (HighLogic.LoadedScene == GameScenes.LOADING)
+			{
 				prefabDefinesTimeEfficCurve = node.HasNode("timeEfficCurve");
+				if (string.IsNullOrEmpty(EcUIUnit))
+				{
+					var rui = Lib.GetResourceUnitInfo(Lib.ECResID);
+					hasRUI = rui != null;
+					if (hasRUI)
+						EcUIUnit = rui.RateUnit;
+					else
+						EcUIUnit = "EC/s";
+				}
+			}
 			if (SolarPanel == null && !GetSolarPanelModule())
 				return;
 
@@ -273,23 +285,24 @@ namespace KERBALISM
 				Fields["panelStatus"].guiActive = true;
 
 			// Update main status field text
+			bool addRate = false;
 			switch (exposureState)
 			{
 				case ExposureState.InShadow:
 					panelStatus = "<color=#ff2222>"+Local.SolarPanelFixer_inshadow +"</color>";//in shadow
-					if (currentOutput > 0.001) panelStatus = Lib.BuildString(currentOutput.ToString(rateFormat), " ", EcUIUnit, ", ", panelStatus);
+					addRate = true;
 					break;
 				case ExposureState.OccludedTerrain:
 					panelStatus = "<color=#ff2222>"+Local.SolarPanelFixer_occludedbyterrain +"</color>";//occluded by terrain
-					if (currentOutput > 0.001) panelStatus = Lib.BuildString(currentOutput.ToString(rateFormat), " ", EcUIUnit, ", ", panelStatus);
+					addRate = true;
 					break;
 				case ExposureState.OccludedPart:
 					panelStatus = Lib.BuildString("<color=#ff2222>", Local.SolarPanelFixer_occludedby.Format(mainOccludingPart), "</color>");//occluded by 
-					if (currentOutput > 0.001) panelStatus = Lib.BuildString(currentOutput.ToString(rateFormat), " ", EcUIUnit, ", ", panelStatus);
+					addRate = true;
 					break;
 				case ExposureState.BadOrientation:
 					panelStatus = "<color=#ff2222>"+Local.SolarPanelFixer_badorientation +"</color>";//bad orientation
-					if (currentOutput > 0.001) panelStatus = Lib.BuildString(currentOutput.ToString(rateFormat), " ", EcUIUnit, ", ", panelStatus);
+					addRate = true;
 					break;
 				case ExposureState.Disabled:
 					switch (state)
@@ -304,9 +317,19 @@ namespace KERBALISM
 					break;
 				case ExposureState.Exposed:
 					sb.Length = 0;
-					sb.Append(currentOutput.ToString(rateFormat));
-					sb.Append(" ");
-					sb.Append(EcUIUnit);
+					if (Settings.UseSIUnits)
+					{
+						if (hasRUI)
+							sb.Append(Lib.SIRate(currentOutput, Lib.ECResID));
+						else
+							sb.Append(Lib.SIRate(currentOutput, EcUIUnit));
+					}
+					else
+					{
+						sb.Append(currentOutput.ToString(rateFormat));
+						sb.Append(" ");
+						sb.Append(EcUIUnit);
+					}
 					if (analyticSunlight)
 					{
 						sb.Append(", ");
@@ -330,6 +353,20 @@ namespace KERBALISM
 					}
 					panelStatus = sb.ToString();
 					break;
+			}
+			if (addRate && currentOutput > 0.001)
+			{
+				if (Settings.UseSIUnits)
+				{
+					if (hasRUI)
+						Lib.BuildString(Lib.SIRate(currentOutput, Lib.ECResID), ", ", panelStatus);
+					else
+						Lib.BuildString(Lib.SIRate(currentOutput, EcUIUnit), ", ", panelStatus);
+				}
+				else
+				{
+					Lib.BuildString(currentOutput.ToString(rateFormat), " ", EcUIUnit, ", ", panelStatus);
+				}
 			}
 		}
 

--- a/src/Kerbalism/Patches/ModuleDataTransmitter_GetInfo.cs
+++ b/src/Kerbalism/Patches/ModuleDataTransmitter_GetInfo.cs
@@ -38,11 +38,11 @@ namespace KERBALISM
 			double ec = __instance.DataResourceCost * __instance.DataRate;
 
 			Specifics specs = new Specifics();
-			specs.Add(Local.DataTransmitter_ECidle, Lib.Color(Lib.HumanReadableRate(ec * Settings.TransmitterPassiveEcFactor), Lib.Kolor.Orange));//"EC (idle)"
+			specs.Add(Local.DataTransmitter_ECidle, Lib.Color(Lib.HumanOrSIRate(ec * Settings.TransmitterPassiveEcFactor, Lib.ECResID), Lib.Kolor.Orange));//"EC (idle)"
 
 			if (__instance.antennaType != AntennaType.INTERNAL) 
 			{
-				specs.Add(Local.DataTransmitter_ECTX, Lib.Color(Lib.HumanReadableRate(ec * Settings.TransmitterActiveEcFactor), Lib.Kolor.Orange));//"EC (transmitting)"
+				specs.Add(Local.DataTransmitter_ECTX, Lib.Color(Lib.HumanOrSIRate(ec * Settings.TransmitterActiveEcFactor, Lib.ECResID), Lib.Kolor.Orange));//"EC (transmitting)"
 				specs.Add("");
 				specs.Add(Local.DataTransmitter_Maxspeed, Lib.HumanReadableDataRate(__instance.DataRate));//"Max. speed"
 			}

--- a/src/Kerbalism/System/Loader.cs
+++ b/src/Kerbalism/System/Loader.cs
@@ -106,6 +106,11 @@ namespace KERBALISM
 			}
 		}
 
+		public static void ModuleManagerPostLoad()
+		{
+			Lib.LoadResourceUnitInfo();
+		}
+
 		void SaveHabitatData()
 		{
 			ConfigNode fakeNode = new ConfigNode();

--- a/src/Kerbalism/System/Settings.cs
+++ b/src/Kerbalism/System/Settings.cs
@@ -100,6 +100,7 @@ namespace KERBALISM
 			ShieldingEfficiencyHardMult = Lib.ConfigValue(cfg, "ShieldingEfficiencyHardMult", 0.8f);
 			ExternRadiation = Lib.ConfigValue(cfg, "ExternRadiation", 0.04f);
 			RadiationInSievert = Lib.ConfigValue(cfg, "RadiationInSievert", false);
+			UseSIUnits = Lib.ConfigValue(cfg, "UseSIUnits", false);
 
 			ModsIncompatible = Lib.ConfigValue(cfg, "ModsIncompatible", MODS_INCOMPATIBLE);
 			ModsWarning = Lib.ConfigValue(cfg, "ModsWarning", MODS_WARNING);
@@ -203,6 +204,7 @@ namespace KERBALISM
 		public static float StormRadiation;
 		public static float ExternRadiation;
 		public static bool RadiationInSievert; // use Sievert iso. rad
+		public static bool UseSIUnits; // use SI units instead of human-readable pretty-printing when available
 
 		// sanity check settings
 		public static string ModsIncompatible;

--- a/src/Kerbalism/UI/Planner/Planner.cs
+++ b/src/Kerbalism/UI/Planner/Planner.cs
@@ -318,9 +318,9 @@ namespace KERBALISM.Planner
 
 			// render the panel section
 			p.AddSection(Local.Planner_ELECTRICCHARGE);//"ELECTRIC CHARGE"
-			p.AddContent(Local.Planner_storage, Lib.HumanReadableAmount(res.storage), tooltip);//"storage"
-			p.AddContent(Local.Planner_consumed, Lib.HumanReadableRate(res.consumed), tooltip);//"consumed"
-			p.AddContent(Local.Planner_produced, Lib.HumanReadableRate(res.produced), tooltip);//"produced"
+			p.AddContent(Local.Planner_storage, Lib.HumanOrSIAmount(res.storage, Lib.ECResID), tooltip);//"storage"
+			p.AddContent(Local.Planner_consumed, Lib.HumanOrSIRate(res.consumed, Lib.ECResID), tooltip);//"consumed"
+			p.AddContent(Local.Planner_produced, Lib.HumanOrSIRate(res.produced, Lib.ECResID), tooltip);//"produced"
 			p.AddContent(Local.Planner_duration, Lib.HumanReadableDuration(res.Lifetime()));//"duration"
 		}
 
@@ -344,9 +344,9 @@ namespace KERBALISM.Planner
 			p.AddSection(Lib.SpacesOnCaps(resource.displayName).ToUpper(), string.Empty,
 				() => { p.Prev(ref resource_index, panel_resource.Count); enforceUpdate = true; },
 				() => { p.Next(ref resource_index, panel_resource.Count); enforceUpdate = true; });
-			p.AddContent(Local.Planner_storage, Lib.HumanReadableAmount(res.storage), tooltip);//"storage"
-			p.AddContent(Local.Planner_consumed, Lib.HumanReadableRate(res.consumed), tooltip);//"consumed"
-			p.AddContent(Local.Planner_produced, Lib.HumanReadableRate(res.produced), tooltip);//"produced"
+			p.AddContent(Local.Planner_storage, Lib.HumanOrSIAmount(res.storage, resource.id), tooltip);//"storage"
+			p.AddContent(Local.Planner_consumed, Lib.HumanOrSIRate(res.consumed, resource.id), tooltip);//"consumed"
+			p.AddContent(Local.Planner_produced, Lib.HumanOrSIRate(res.produced, resource.id), tooltip);//"produced"
 			p.AddContent(Local.Planner_duration, Lib.HumanReadableDuration(res.Lifetime()));//"duration"
 		}
 

--- a/src/Kerbalism/UI/Planner/SimulatedResource.cs
+++ b/src/Kerbalism/UI/Planner/SimulatedResource.cs
@@ -218,11 +218,12 @@ namespace KERBALISM.Planner
 			IDictionary<string, Wrapper> red = !invert ? consumers : producers;
 
 			StringBuilder sb = new StringBuilder();
+			int id = resource_name.GetHashCode();
 			foreach (KeyValuePair<string, Wrapper> pair in green)
 			{
 				if (sb.Length > 0)
 					sb.Append("\n");
-				sb.Append(Lib.Color(Lib.HumanReadableRate(pair.Value.value), Lib.Kolor.PosRate, true));
+				sb.Append(Lib.Color(Lib.HumanOrSIRate(pair.Value.value, id), Lib.Kolor.PosRate, true));
 				sb.Append("\t");
 				sb.Append(pair.Key);
 			}
@@ -230,7 +231,7 @@ namespace KERBALISM.Planner
 			{
 				if (sb.Length > 0)
 					sb.Append("\n");
-				sb.Append(Lib.Color(Lib.HumanReadableRate(pair.Value.value), Lib.Kolor.NegRate, true));
+				sb.Append(Lib.Color(Lib.HumanOrSIRate(pair.Value.value, id), Lib.Kolor.NegRate, true));
 				sb.Append("\t");
 				sb.Append(pair.Key);
 			}

--- a/src/Kerbalism/UI/Telemetry.cs
+++ b/src/Kerbalism/UI/Telemetry.cs
@@ -171,8 +171,8 @@ namespace KERBALISM
 				if (res.AverageRate != 0.0)
 				{
 					sb.Append(Lib.Color(res.AverageRate > 0.0,
-						Lib.BuildString("+", Lib.HumanReadableRate(Math.Abs(res.AverageRate))), Lib.Kolor.PosRate,
-						Lib.BuildString("-", Lib.HumanReadableRate(Math.Abs(res.AverageRate))), Lib.Kolor.NegRate,
+						Lib.BuildString("+", Lib.HumanOrSIRate(Math.Abs(res.AverageRate), resource.id)), Lib.Kolor.PosRate,
+						Lib.BuildString("-", Lib.HumanOrSIRate(Math.Abs(res.AverageRate), resource.id)), Lib.Kolor.NegRate,
 						true));
 				}
 				else
@@ -198,9 +198,9 @@ namespace KERBALISM
 				else sb.Append("   "); // spaces to prevent alignement issues
 
 				sb.Append("\t");
-				sb.Append(res.Amount.ToString("F1"));
+				sb.Append(Lib.HumanOrSIAmount(res.Amount, resource.id));
 				sb.Append("/");
-				sb.Append(res.Capacity.ToString("F1"));
+				sb.Append(Lib.HumanOrSIAmount(res.Capacity, resource.id));
 				sb.Append(" (");
 				sb.Append(res.Level.ToString("P0"));
 				sb.Append(")");
@@ -213,8 +213,8 @@ namespace KERBALISM
 					{
 						sb.Append("\n");
 						sb.Append(Lib.Color(rb.rate > 0.0,
-							Lib.BuildString("+", Lib.HumanReadableRate(Math.Abs(rb.rate)), "   "), Lib.Kolor.PosRate, // spaces to mitigate alignement issues
-							Lib.BuildString("-", Lib.HumanReadableRate(Math.Abs(rb.rate)), "   "), Lib.Kolor.NegRate, // spaces to mitigate alignement issues
+							Lib.BuildString("+", Lib.HumanOrSIRate(Math.Abs(rb.rate), resource.id), "   "), Lib.Kolor.PosRate, // spaces to mitigate alignement issues
+							Lib.BuildString("-", Lib.HumanOrSIRate(Math.Abs(rb.rate), resource.id), "   "), Lib.Kolor.NegRate, // spaces to mitigate alignement issues
 							true)); 
 						sb.Append("\t");
 						sb.Append(rb.broker.Title);


### PR DESCRIPTION
This PR does one big thing and two small things, all regarding units.

* It adds support for printing in SI units, and as part of this adds support for resources to have their units specified via the ResourceUnitInfo class (which is loaded directly from the RESOURCE_DEFINITION node). When Settings.UseSIUnits is set to true, instead of using HumanReadableRate / Amount / Pressure / etc, SI versions of these will be used according to what is specified for the given resource. For example, for ElectricCharge, you can add `amountUnit = J`, `rateUnit = W`, `multiplierToUnit = 1000` and Kerbalism will report EC in W[atts] (for rates) and J[oules] for (for amounts), with the base of 1 EC = 1 kJ. Most places where a HumanReadable amount or rate is called, HumanOrSI methods are called that take the arguments required for both. By contrast the other HumanReadables (Pressure, Field, etc) have their branching in the method itself.
* When Earth time is specified in KSP's GameSettings, it's actually used, rather than always using the homebody's day length and year length regardless of the player choosing local/ingame time ("Kerbin time") or out-of-game time ("Earth Time").
* Data amount and rate now includes bits as well as bytes. This is particularly important for RealAntenna support, since there data rates can go as low as 0.1b/s (and in RP-1 experiment data rates can be equally low).

Docs for UseSIUnits and ResourceUnitInfo:

When `UseSIUnits = true` is specified in Settings.cfg, we use SI units when available when pretty-printing, via adding unit info to RESOURCE_DEFINITION.

You can add:

* `amountUnit` - the string to use as the unit for amounts
* `rateUnit` (if unspecified, amountUnit will be used, and /s appended if `useRatePostfix` isn't set to false
* `multiplierToUnit` - defaults to 1. Used if the resource amount and the unit don't match (e.g. Megajoules being MJ not J)
* `useHuman` - if specified will use the rate and amount units but not SI (i.e. will display in human-readable rate, and the total without milli/kilo/etc for amounts). If this is specified, `useRatePostfix` is treated as false regardless of its value
* Note: a resource that doesn't have at least `amountUnit` specified won't be valid and won't be used by UseSIUnits