### PR TITLE
Fix handling of inclination for experiments when Principia is installed

### DIFF
--- a/src/Kerbalism/Lib.cs
+++ b/src/Kerbalism/Lib.cs
@@ -137,6 +137,29 @@ namespace KERBALISM
 			}
 		}
 
+		public static double PrincipiaCorrectInclination(Orbit o)
+		{
+			if (HasPrincipia && o.referenceBody != (FlightGlobals.currentMainBody ?? Planetarium.fetch.Home))
+			{
+				Vector3d polarAxis = o.referenceBody.BodyFrame.Z;
+
+				double hSqrMag = o.h.sqrMagnitude;
+				if (hSqrMag == 0d)
+				{
+					return Math.Acos(Vector3d.Dot(polarAxis, o.pos) / o.pos.magnitude) * (180.0 / Math.PI);
+				}
+				else
+				{
+					Vector3d orbitZ = o.h / Math.Sqrt(hSqrMag);
+					return Math.Atan2((orbitZ - polarAxis).magnitude, (orbitZ + polarAxis).magnitude) * (2d * (180.0 / Math.PI));
+				}
+			}
+			else
+			{
+				return o.inclination;
+			}
+		}
+
 		///<summary>swap two variables</summary>
 		public static void Swap<T>(ref T a, ref T b)
 		{

--- a/src/Kerbalism/Lib.cs
+++ b/src/Kerbalism/Lib.cs
@@ -124,6 +124,19 @@ namespace KERBALISM
 			return false;
 		}
 
+		private static bool? hasPrincipia = null;
+		public static bool HasPrincipia
+		{
+			get
+			{
+				if (!hasPrincipia.HasValue)
+				{
+					hasPrincipia = HasAssembly("ksp_plugin_adapter");
+				}
+				return hasPrincipia.Value;
+			}
+		}
+
 		///<summary>swap two variables</summary>
 		public static void Swap<T>(ref T a, ref T b)
 		{

--- a/src/Kerbalism/Science/ExperimentRequirements.cs
+++ b/src/Kerbalism/Science/ExperimentRequirements.cs
@@ -124,8 +124,8 @@ namespace KERBALISM
 				results[i] = new RequireResult(Requires[i]);
 				switch (Requires[i].require)
 				{
-					case Require.OrbitMinInclination   : TestReq((c, r) => c >= r, v.orbit.inclination,         (double)Requires[i].value, results[i]); break;
-					case Require.OrbitMaxInclination   : TestReq((c, r) => c <= r, v.orbit.inclination,         (double)Requires[i].value, results[i]); break;
+					case Require.OrbitMinInclination   : TestReq((c, r) => c >= r, Lib.PrincipiaCorrectInclination(v.orbit),  (double)Requires[i].value, results[i]); break;
+					case Require.OrbitMaxInclination   : TestReq((c, r) => c <= r, Lib.PrincipiaCorrectInclination(v.orbit),  (double)Requires[i].value, results[i]); break;
 					case Require.OrbitMinEccentricity  : TestReq((c, r) => c >= r, v.orbit.eccentricity,        (double)Requires[i].value, results[i]); break;
 					case Require.OrbitMaxEccentricity  : TestReq((c, r) => c <= r, v.orbit.eccentricity,        (double)Requires[i].value, results[i]); break;
 					case Require.OrbitMinArgOfPeriapsis: TestReq((c, r) => c >= r, v.orbit.argumentOfPeriapsis, (double)Requires[i].value, results[i]); break;


### PR DESCRIPTION
See https://github.com/KSP-RO/RP-1/issues/2276 - when an experiment has a min or max inclination, and the current mainbody is not the vessel's orbit's mainbody, Kerbalism doesn't correct the orbit's inclination for the body's tilt. Here we (a) cache if Principia is installed, and (b) in the case where the bodies don't match, we recompute inclination based on the body's scaledBody's rotation and the stock code for computing inclination based on orbital state vectors.