### PR TITLE
Support priority in analytic resource processing (defaults to off)

### DIFF
--- a/GameData/KerbalismConfig/Settings.cfg
+++ b/GameData/KerbalismConfig/Settings.cfg
@@ -64,6 +64,7 @@ Kerbalism
   // ModsWarning = none
 
   UseSamplingSunFactor = false        // use experimental sunlight factor calculation for fast time warps
+  UseResourcePriority = false         // whether to respect part flow priority when applying resource deltas
   
   // debug / logging
   VolumeAndSurfaceLogging = false      // set to true to have the full output of crewed parts volume/surface calculations written to the KSP.log

--- a/src/Kerbalism/System/Settings.cs
+++ b/src/Kerbalism/System/Settings.cs
@@ -108,6 +108,7 @@ namespace KERBALISM
 			CheckForCRP = Lib.ConfigValue(cfg, "CheckForCRP", true);
 
 			UseSamplingSunFactor = Lib.ConfigValue(cfg, "UseSamplingSunFactor", false);
+			UseResourcePriority = Lib.ConfigValue(cfg, "UseResourcePriority", false);
 
 			// debug / logging
 			VolumeAndSurfaceLogging = Lib.ConfigValue(cfg, "VolumeAndSurfaceLogging", false);
@@ -213,6 +214,7 @@ namespace KERBALISM
 		public static bool CheckForCRP;
 
 		public static bool UseSamplingSunFactor;
+		public static bool UseResourcePriority;
 
 		// debug / logging
 		public static bool VolumeAndSurfaceLogging;


### PR DESCRIPTION
Also use resource ID when possible. Note: if we were willing to accept the GC impact of creating wrappers for PartResource vs ProtoPartResourceSnapshot or if we static-allocated a bunch of holders (or if C# supported type-specific generic methods, grr) we could eliminate a bunch of duplicate code between loaded and unloaded vessels.

Given the switch to straight int keys rather than having to gethashcode on strings all the time, my hope is this will be about as fast as before.