### PR TITLE
Fix solar fraction landed by fixing dumb typo left over from refactoring

### DIFF
--- a/src/Kerbalism/Sim.cs
+++ b/src/Kerbalism/Sim.cs
@@ -126,10 +126,10 @@ namespace KERBALISM
 					return Vector3d.Dot(sunVec, mb.position - vPos) < 0 ? 0 : 1.0;
 				}
 
-				// Just assume half the body's rotation period (note that
-				// for landed vessels, the orbital period is considered the
-				// body's rotation period).
-				return 0.5 * mb.rotationPeriod;
+				// Just assume half the time, since for non-tidally-locked
+				// bodies without axial tilt, for sufficiently large timesteps
+				// half the time will be spent in sunlight.
+				return 0.5;
 			}
 
 			double e = obt.eccentricity;


### PR DESCRIPTION
Partway through the Solar PR, I refactored the analytic exposure calcs to report the fraction of time spent in shadow (eclipse fraction, in IRL terminology) rather than the absolute time spent in eclipse (which in the existing code was then just divided by the orbital period to get the fraction anyway).

When doing so, however, I left one place where I was still reporting time rather than fraction. This meant landed vessels with non-NaN inclinations had wonky eclipse fractions, which would do things like making them always in shadow or possibly make things go NaN (this is a speculative fix to #875 per discord).

Sorry.