### PR TITLE
Fix for sickbays erroneously consuming resources after rendezvous

### DIFF
--- a/src/Kerbalism/Modules/Sickbay.cs
+++ b/src/Kerbalism/Modules/Sickbay.cs
@@ -77,7 +77,7 @@ namespace KERBALISM
 			}
 
 			// configure on start
-			Configure(true, slots, cureEverybody);
+			Configure(isEnabled & running, slots, cureEverybody);
 
 			UpdateActions();
 		}
@@ -122,7 +122,7 @@ namespace KERBALISM
 			}
 			RemovePatients(removeList);
 
-			Configure(running, slots, cureEverybody);
+			Configure(isEnabled & running, slots, cureEverybody);
 
 			if (part.IsPAWVisible())
 				UpdateActions();


### PR DESCRIPTION
This is a fix for a bug I found with sickbays where rendezvousing with a vessel that contains a part with a configurable sickbay would cause it to start consuming electricity and other resources as if all possible sickbay modules were running at the same time. To reproduce the bug, launch a vessel with a PPD-10 Hitchhiker crew container with nothing configured in the sickbay, and then launch a 2nd vessel and rendezvous with the first. When the vessel with the Hitchhiker container comes within physics range and loads into the scene, it will immediately start consuming electricity and oxygen for both the sickbay TV and RDU processes, despite originally being configured with neither sickbay modules. This bug is present in both Kerbalism versions 3.18 and 3.19.

Here are screenshots showing electricity consumption before and after rendezvousing for the target vessel that has a PPD-10 Hitchhiker part on it:

Before rendezvous:
![before-rendezvous](https://github.com/Kerbalism/Kerbalism/assets/12609432/f75b98c0-c0f5-41f9-a911-e277300758a1)
After rendezvous:
![after-rendezvous](https://github.com/Kerbalism/Kerbalism/assets/12609432/2d246b4b-cbd3-48e6-8a26-1c2ddabd12fb)

As shown in the screenshots, the vessel has started consuming electricity and oxygen for the RDU and TV, despite being configured with neither when launched.

When debugging this, I discovered that loading a vessel normally by launching or focusing it from the tracking station would call `Sickbay.Start()` immediately followed by `Sickbay.Update()`, however when rendezvousing with the vessel, only `Sickbay.Start()` would be called. If both Start and Update are called, the resulting `amount` values for `_SickbayTV` and `_SickbayRDU` are set to 0, but if only Start is called, the `amount` values would end up being set to 1. This is because `Sickbay.Start()` calls `Sickbay.Configure()` with the first parameter hardcoded to `true`, resulting in `Lib.SetResource()` to be called for the TV and RDU with an `amount` value of 1. I am unsure if rendezvouses only calling `Sickbay.Start()` without calling `Sickbay.Update()` is a separate bug or not.

This change now ensures that the `amount` value for `_SickbayTV` and `_SickbayRDU` will only be set to 1 if the sickbay module configured in the part, which will set `isEnabled` to `true`. Otherwise, if the sickbay is not configured, `isEnabled` for `_SickbayTV` and `_SickbayRDU` will be `false`, and the `amount` value will always be 0.

I have tested this change with various different sickbay configurations and have not found any erroneous behavior.