### PR TITLE
Add habitats for pressurized modules in Stockalike Station Parts Redux

### DIFF
--- a/GameData/KerbalismConfig/Support/SSPX.cfg
+++ b/GameData/KerbalismConfig/Support/SSPX.cfg
@@ -1354,3 +1354,177 @@
 }
 
 //end
+
+// ============================================================================
+// habitats for pressurized structural parts
+// ============================================================================
+
+// Habitats for rigid pressurized crew tubes, such as sspx-tube-1875-angled-1 and sspx-tube-1875-2
+@PART[sspx-tube-*]:HAS[!MODULE[Habitat],!MODULE[KerbalSeat]]:NEEDS[FeatureHabitat]:FOR[KerbalismDefault]
+{
+  MODULE
+  {
+	name = Habitat
+  }
+  MODULE
+  {
+	name = Sensor
+	type = temperature
+  }
+  MODULE
+  {
+	name = Sensor
+	type = radiation
+  }
+  MODULE
+  {
+	name = Sensor
+	type = habitat_radiation
+  }
+}
+
+// Habitats for extendable crew tubes, such as sspx-extendable-tube-125-1
+@PART[sspx-extendable-tube-*]:HAS[!MODULE[Habitat],!MODULE[KerbalSeat]]:NEEDS[FeatureHabitat]:FOR[KerbalismDefault]
+{
+  MODULE
+  {
+	name = Habitat
+  }
+  MODULE
+  {
+	name = Sensor
+	type = temperature
+  }
+  MODULE
+  {
+	name = Sensor
+	type = radiation
+  }
+  MODULE
+  {
+	name = Sensor
+	type = habitat_radiation
+  }
+}
+
+// Habitats for size adapters, such as sspx-adapter-1875-0625-1 and sspx-adapter-1875-125-2
+@PART[sspx-adapter-*]:HAS[!MODULE[Habitat],!MODULE[KerbalSeat]]:NEEDS[FeatureHabitat]:FOR[KerbalismDefault]
+{
+  MODULE
+  {
+	name = Habitat
+  }
+  MODULE
+  {
+	name = Sensor
+	type = temperature
+  }
+  MODULE
+  {
+	name = Sensor
+	type = radiation
+  }
+  MODULE
+  {
+	name = Sensor
+	type = habitat_radiation
+  }
+}
+
+// Habitats for radial connectors, such as sspx-attach-1875-1
+@PART[sspx-attach-*]:HAS[!MODULE[Habitat],!MODULE[KerbalSeat]]:NEEDS[FeatureHabitat]:FOR[KerbalismDefault]
+{
+  MODULE
+  {
+	name = Habitat
+  }
+  MODULE
+  {
+	name = Sensor
+	type = temperature
+  }
+  MODULE
+  {
+	name = Sensor
+	type = radiation
+  }
+  MODULE
+  {
+	name = Sensor
+	type = habitat_radiation
+  }
+}
+
+// Habitats for the six-way adapters, such as sspx-hub-1875-1
+@PART[sspx-hub-*]:HAS[!MODULE[Habitat],!MODULE[KerbalSeat]]:NEEDS[FeatureHabitat]:FOR[KerbalismDefault]
+{
+  MODULE
+  {
+	name = Habitat
+  }
+  MODULE
+  {
+	name = Sensor
+	type = temperature
+  }
+  MODULE
+  {
+	name = Sensor
+	type = radiation
+  }
+  MODULE
+  {
+	name = Sensor
+	type = habitat_radiation
+  }
+}
+
+// Habitats for cupolas, such as sspx-cupola-greenhouse-125-1 and sspx-cupola-1875-1
+@PART[sspx-cupola-*]:HAS[!MODULE[Habitat],!MODULE[KerbalSeat]]:NEEDS[FeatureHabitat]:FOR[KerbalismDefault]
+{
+  MODULE
+  {
+	name = Habitat
+  }
+  MODULE
+  {
+	name = Sensor
+	type = temperature
+  }
+  MODULE
+  {
+	name = Sensor
+	type = radiation
+  }
+  MODULE
+  {
+	name = Sensor
+	type = habitat_radiation
+  }
+}
+
+// Habitats for domes, including sspx-dome-greenhouse-5-1 and sspx-dome-habitation-5-1
+@PART[sspx-dome-*]:HAS[!MODULE[Habitat],!MODULE[KerbalSeat]]:NEEDS[FeatureHabitat]:FOR[KerbalismDefault]
+{
+  MODULE
+  {
+	name = Habitat
+  }
+  MODULE
+  {
+	name = Sensor
+	type = temperature
+  }
+  MODULE
+  {
+	name = Sensor
+	type = radiation
+  }
+  MODULE
+  {
+	name = Sensor
+	type = habitat_radiation
+  }
+}
+
+// end


### PR DESCRIPTION
A lot of parts in Space Station Parts Redux are described as being pressurized, but they lack Habitat modules. This PR simply adds Habitat functionality to the parts that seem to deserve it.

For example, SSPX greenhouse modules (the little cupola and the 5m dome) lack habitats, in contrast to the Kerbalism greenhouse which has that module. Also, the "pressurized crew tube" parts lack habitats too.

Effects of this:

 * spacecraft built with these parts will effectively have a larger habitable area
 * like any Habitat, this costs electricity and nitrogen to maintain
 * like any Habitat, this can be toggled off

I've been testing in my own game (in the Kerbin system with the Default profile of Kerbalism) and it seems to work great. The habitat surface area and volume auto-generated appear comparable to similar parts that already have habitats (the SSPX crew and science modules, for example)