### PR TITLE
Mod Support: Interstellar Science Drill

### DIFF
--- a/GameData/KerbalismConfig/Support/WarpPlugin.cfg
+++ b/GameData/KerbalismConfig/Support/WarpPlugin.cfg
@@ -1,0 +1,25 @@
+@KERBALISM_EXPERIMENT_VALUES:NEEDS[WarpPlugin,FeatureScience]
+{
+  %WarpPlugin
+  {
+    drillSample
+    {
+      size = 1024         // size in MB. If the experiment is a sample, this define how many slots it uses :  1024 MB = 1 slot.
+    }
+  }
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[drillSample]]:NEEDS[WarpPlugin,FeatureScience]:FOR[zzzKerbalismDefault]
+{
+	@dataScale = #$@KERBALISM_EXPERIMENT_VALUES/WarpPlugin/drillSample/size$
+	@dataScale /= #$baseValue$
+}
+
+@PART[KspiSampleDrill]:NEEDS[WarpPlugin,FeatureScience]:FOR[KerbalismDefault]
+{
+  @MODULE[ModuleScienceExperiment]
+  {
+    @xmitDataScalar = 0 //0 -> is a sample
+    data_rate = #$@KERBALISM_EXPERIMENT_VALUES/WarpPlugin/drillSample/size$ // 1 slot
+  }
+}


### PR DESCRIPTION
The KSP Interstellar Extended Science Drill produces a transmittable file instead of a sample like the EVA surface samples. This adds a .cfg file that patches the Interstellar Science Drill. Changes the science result to be a sample instead of a transmittable file. This simply changes the xmitDataScalar value to 0 and sets the data rate to 1 slot (1024MB). Does not add a KerbalismExperiment Module since I wanted to keep the extra functionality that KSPIE has with the drill.

There might be a couple more science experiments from KSPIE that could be patched as well and added to this PR, I haven't looked into the others yet.