### PR TITLE
Error handling fallback for NaN dampingExponent when using RemoteTech

### DIFF
--- a/src/Kerbalism/Sim.cs
+++ b/src/Kerbalism/Sim.cs
@@ -1265,6 +1265,12 @@ namespace KERBALISM
 				dampingExponent = Math.Log(desiredRateAt2AU / baseRate, strengthAt2AU);
 
 				// 2.4 seems good for RemoteTech
+				if (dampingExponent.ToString("F4") == "NaN")
+				{
+					Lib.Log("dampingExponent is " + dampingExponent + ",... setting to 2.4");
+					dampingExponent = 2.4;
+				}
+
 				return DataRateDampingExponent;
 			}
 		}

--- a/src/Kerbalism/Sim.cs
+++ b/src/Kerbalism/Sim.cs
@@ -1265,7 +1265,7 @@ namespace KERBALISM
 				dampingExponent = Math.Log(desiredRateAt2AU / baseRate, strengthAt2AU);
 
 				// 2.4 seems good for RemoteTech
-				if (dampingExponent.ToString("F4") == "NaN")
+				if (double.IsNaN(dampingExponent))
 				{
 					Lib.Log("dampingExponent is " + dampingExponent + ",... setting to 2.4");
 					dampingExponent = 2.4;


### PR DESCRIPTION
There probably is a more comprehensive fix to ensure that dampingExponent is never NaN.  Maybe redoing the SignalStrength so it never takes the LOG(0).  But this simple error check is not likely to break anything else, as it only executes on NaN.