### PR TITLE
ProcessController and related code refactor

### DIFF
--- a/GameData/Kerbalism/Kerbalism.version
+++ b/GameData/Kerbalism/Kerbalism.version
@@ -3,7 +3,7 @@
   "URL": "https://raw.githubusercontent.com/Kerbalism/Kerbalism/master/GameData/Kerbalism/Kerbalism.version",
   "DOWNLOAD": "https://github.com/Kerbalism/Kerbalism/releases",
   "CHANGE_LOG_URL": "https://github.com/Kerbalism/Kerbalism/blob/master/CHANGELOG.md",
-  "VERSION": {"MAJOR": 3, "MINOR": 24, "PATCH": 0, "BUILD": 0},
+  "VERSION": {"MAJOR": 3, "MINOR": 25, "PATCH": 0, "BUILD": 0},
   "KSP_VERSION": {"MAJOR": 1, "MINOR": 12, "PATCH": 0},
   "KSP_VERSION_MIN": {"MAJOR": 1, "MINOR": 8, "PATCH": 0},
   "KSP_VERSION_MAX": {"MAJOR": 1, "MINOR": 12, "PATCH": 9}

--- a/GameData/Kerbalism/VersionConfig.xml
+++ b/GameData/Kerbalism/VersionConfig.xml
@@ -14,7 +14,7 @@ The values defined here will be propagated to :
     Kerbalism major and minor version numbers 
     -->
 		<KerbalismVersionMajor>3</KerbalismVersionMajor>
-		<KerbalismVersionMinor>24</KerbalismVersionMinor>
+		<KerbalismVersionMinor>25</KerbalismVersionMinor>
     <!-- 
     Must match the `include=XXXX` of a KBinVersionConstant item, 
     used to determine the lowest and highest supported KSP version in the Kerbalism.version KSP-AVC file.

--- a/src/Kerbalism/Automation/Computer.cs
+++ b/src/Kerbalism/Automation/Computer.cs
@@ -288,9 +288,6 @@ namespace KERBALISM
 					// get part prefab (required for module properties)
 					Part part_prefab = PartLoader.getPartInfoByName(p.partName).partPrefab;
 
-					// get all module prefabs
-					var module_prefabs = part_prefab.FindModulesImplementing<PartModule>();
-
 					// clear module indexes
 					PD.Clear();
 
@@ -299,7 +296,7 @@ namespace KERBALISM
 					{
 						// get the module prefab
 						// if the prefab doesn't contain this module, skip it
-						PartModule module_prefab = Lib.ModulePrefab(module_prefabs, m.moduleName, PD);
+						PartModule module_prefab = Lib.ModulePrefab(part_prefab.Modules, m.moduleName, PD);
 						if (!module_prefab) continue;
 
 						// if the module is disabled, skip it

--- a/src/Kerbalism/Automation/Devices/Process.cs
+++ b/src/Kerbalism/Automation/Devices/Process.cs
@@ -40,20 +40,21 @@ namespace KERBALISM
 
 		public override string Tooltip => Lib.BuildString(base.Tooltip, "\n", Lib.Bold("Process capacity :"), "\n", prefab.ModuleInfo);
 
-		public override string Status => Lib.Color(Lib.Proto.GetBool(protoModule, "running"), Local.Generic_RUNNING, Lib.Kolor.Green, Local.Generic_STOPPED, Lib.Kolor.Yellow);
+		public override string Status => Lib.Color(Lib.Proto.GetBool(protoModule, nameof(ProcessController.running)), Local.Generic_RUNNING, Lib.Kolor.Green, Local.Generic_STOPPED, Lib.Kolor.Yellow);
 
 		public override void Ctrl(bool value)
 		{
-			Lib.Proto.Set(protoModule, "running", value);
+			if (Lib.Proto.GetBool(protoModule, nameof(ProcessController.broken)))
+				return;
 
-			double capacity = prefab.capacity;
+			Lib.Proto.Set(protoModule, nameof(ProcessController.running), value);
 			var res = protoPart.resources.Find(k => k.resourceName == prefab.resource);
-			res.amount = value ? capacity : 0.0;
+			if (res != null) res.flowState = value;
 		}
 
 		public override void Toggle()
 		{
-			Ctrl(!Lib.Proto.GetBool(protoModule, "running"));
+			Ctrl(!Lib.Proto.GetBool(protoModule, nameof(ProcessController.running)));
 		}
 	}
 

--- a/src/Kerbalism/Background.cs
+++ b/src/Kerbalism/Background.cs
@@ -203,9 +203,6 @@ namespace KERBALISM
 				// get part prefab (required for module properties)
 				Part part_prefab = PartLoader.getPartInfoByName(p.partName).partPrefab;
 
-				// get all module prefabs
-				var module_prefabs = part_prefab.FindModulesImplementing<PartModule>();
-
 				// clear module indexes
 				PD.Clear();
 
@@ -217,7 +214,7 @@ namespace KERBALISM
 
 					// get the module prefab
 					// if the prefab doesn't contain this module, skip it
-					PartModule module_prefab = Lib.ModulePrefab(module_prefabs, m.moduleName, PD);
+					PartModule module_prefab = Lib.ModulePrefab(part_prefab.Modules, m.moduleName, PD);
 					if (!module_prefab) continue;
 
 					// if the module is disabled, skip it

--- a/src/Kerbalism/Database/DB.cs
+++ b/src/Kerbalism/Database/DB.cs
@@ -117,6 +117,9 @@ namespace KERBALISM
                 ui = new UIData();
             }
 
+			// migrate pre-3.25 process controllers
+			ProcessController.MigrateSaves(version);
+
 			// if an old savegame was imported, log some debug info
 			if (version != Lib.KerbalismVersion) Lib.Log("savegame converted from version " + version + " to " + Lib.KerbalismVersion);
         }

--- a/src/Kerbalism/Database/KerbalData.cs
+++ b/src/Kerbalism/Database/KerbalData.cs
@@ -62,6 +62,8 @@ namespace KERBALISM
 				}
 			}
 			rules = cleaned;
+			// remove all sickbay cures
+			sickbay = string.Empty;
 		}
 
 		public RuleData Rule(string name)

--- a/src/Kerbalism/Database/ReliabilityInfo.cs
+++ b/src/Kerbalism/Database/ReliabilityInfo.cs
@@ -104,9 +104,6 @@ namespace KERBALISM
 					// get part prefab (required for module properties)
 					Part part_prefab = PartLoader.getPartInfoByName(p.partName).partPrefab;
 
-					// get all module prefabs
-					var module_prefabs = part_prefab.FindModulesImplementing<PartModule>();
-
 					// clear module indexes
 					PD.Clear();
 
@@ -115,7 +112,7 @@ namespace KERBALISM
 					{
 						if (m.moduleName != "Reliability") continue;
 
-						Reliability module_prefab = Lib.ModulePrefab(module_prefabs, m.moduleName, PD) as Reliability;
+						Reliability module_prefab = Lib.ModulePrefab(part_prefab.Modules, m.moduleName, PD) as Reliability;
 						if (!module_prefab) continue;
 
 						// if the module is disabled, skip it

--- a/src/Kerbalism/Modules/Configure.cs
+++ b/src/Kerbalism/Modules/Configure.cs
@@ -16,7 +16,7 @@ namespace KERBALISM
 	public interface IConfigurable
 	{
 		// configure the module
-		void Configure(bool enable);
+		void Configure(bool enable, int multiplier);
 
 		// called only if the module is part of a configure setup, and only on the prefab
 		// see Kerbalism.
@@ -138,10 +138,14 @@ namespace KERBALISM
 			}
 		}
 
-		void IConfigurable.Configure(bool enable)
+		void IConfigurable.Configure(bool enable, int multiplier)
 		{
 			enabled = enable;
 			isEnabled = enable;
+			// note that we ignore the multiplier here.
+			// this mean configure modules themselves configured by a configure module
+			// can't handle multiple slots having the same setup. Supporting this would
+			// require a complete refactor of how things are handled.
 			DoConfigure();
 		}
 
@@ -234,7 +238,7 @@ namespace KERBALISM
 
 						// call configure/deconfigure functions on module if available
 						if (m is IConfigurable configurable_module)
-							configurable_module.Configure(active);
+							configurable_module.Configure(active, count);
 					}
 				}
 

--- a/src/Kerbalism/Modules/Experiment.cs
+++ b/src/Kerbalism/Modules/Experiment.cs
@@ -849,15 +849,13 @@ namespace KERBALISM
 				{
 					// get part prefab (required for module properties)
 					Part part_prefab = PartLoader.getPartInfoByName(p.partName).partPrefab;
-					// get all module prefabs
-					var module_prefabs = part_prefab.FindModulesImplementing<PartModule>();
 					// clear module indexes
 					PD.Clear();
 					foreach (ProtoPartModuleSnapshot m in p.modules)
 					{
 						// get the module prefab
 						// if the prefab doesn't contain this module, skip it
-						PartModule module_prefab = Lib.ModulePrefab(module_prefabs, m.moduleName, PD);
+						PartModule module_prefab = Lib.ModulePrefab(part_prefab.Modules, m.moduleName, PD);
 						if (!module_prefab) continue;
 						// if the module is disabled, skip it
 						// note: this must be done after ModulePrefab is called, so that indexes are right

--- a/src/Kerbalism/Modules/Experiment.cs
+++ b/src/Kerbalism/Modules/Experiment.cs
@@ -124,8 +124,9 @@ namespace KERBALISM
 
 		#region init / parsing
 
-		public void Configure(bool enable)
+		public void Configure(bool enable, int multiplier)
 		{
+			// multiplier is ignored for experiments
 			enabled = enable;
 			isEnabled = enable;
 		}

--- a/src/Kerbalism/Modules/Greenhouse.cs
+++ b/src/Kerbalism/Modules/Greenhouse.cs
@@ -49,7 +49,8 @@ namespace KERBALISM
 
 		private bool isConfigurable = false;
 
-		public void Configure(bool enable) {
+		public void Configure(bool enable, int multiplier) {
+			// multiplier is ignored for greenhouses
 			active = enable;
 			if(!active) {
 				growth = 0;

--- a/src/Kerbalism/Modules/Sickbay.cs
+++ b/src/Kerbalism/Modules/Sickbay.cs
@@ -84,8 +84,15 @@ namespace KERBALISM
 
 		public void Configure(bool enable, int slots, bool cureEverybody)
 		{
-			if (cureEverybody) Lib.SetProcessEnabledDisabled(part, resource, enable, capacity);
-			else Lib.SetProcessEnabledDisabled(part, resource, enable, capacity * slots);
+			double configuredCapacity = cureEverybody ? capacity : capacity * slots;
+
+			if (!part.Resources.Contains(resource))
+				Lib.AddResource(part, resource, 0.0, configuredCapacity);
+
+			if (enable)
+				Lib.SetResource(part, resource, configuredCapacity, configuredCapacity);
+			else
+				Lib.SetResource(part, resource, 0.0, configuredCapacity);
 		}
 
 		public void Update()

--- a/src/Kerbalism/Properties/AssemblyInfo.cs
+++ b/src/Kerbalism/Properties/AssemblyInfo.cs
@@ -23,5 +23,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can use the default the Revision and
 // Build Numbers by using the '*' as shown below:
-[assembly: AssemblyVersion("3.24")]
-[assembly: AssemblyFileVersion("3.24")]
+[assembly: AssemblyVersion("3.25")]
+[assembly: AssemblyFileVersion("3.25")]

--- a/src/Kerbalism/System/API.cs
+++ b/src/Kerbalism/System/API.cs
@@ -575,15 +575,13 @@ namespace KERBALISM
 				{
 					// get part prefab (required for module properties)
 					Part part_prefab = PartLoader.getPartInfoByName(p.partName).partPrefab;
-					// get all module prefabs
-					var module_prefabs = part_prefab.FindModulesImplementing<PartModule>();
 					// clear module indexes
 					PD.Clear();
 					foreach (ProtoPartModuleSnapshot m in p.modules)
 					{
 						// get the module prefab
 						// if the prefab doesn't contain this module, skip it
-						PartModule module_prefab = Lib.ModulePrefab(module_prefabs, m.moduleName, PD);
+						PartModule module_prefab = Lib.ModulePrefab(part_prefab.Modules, m.moduleName, PD);
 						if (!module_prefab) continue;
 						// if the module is disabled, skip it
 						// note: this must be done after ModulePrefab is called, so that indexes are right

--- a/src/KerbalismBootstrap/Properties/AssemblyInfo.cs
+++ b/src/KerbalismBootstrap/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.24.*")]
-[assembly: AssemblyFileVersion("3.24")]
+[assembly: AssemblyVersion("3.25.*")]
+[assembly: AssemblyFileVersion("3.25")]


### PR DESCRIPTION
This notably aim at fixing the following issues :
- #642
- #940
- #941 
- #942 

Main change is reverting this commit : ac24298f56a7111e76d561c673e916dc840ee433 (note that other related changes were made following this commit as it broke a bunch of stuff)

Originally, ProcessControllers enabled state toggling (either by the user or by a Reliability module) was done by toggling the pseudo-resource `flowState`. The mentioned commit changed that logic to instead alter the pseudo-resource amount (setting it either zero or maxAmount), which notably broke self-consuming processes (see issue #940), and more generally made things a lot messier.

Aside from fixing issue #940, reverting this change was necessary to implement the fix for issue #642, and more generally it make the overall implementation a lot cleaner.

The PR implement a save/craft persisted data migration code to preserve backward compatibility with existing saves from 3.24 and below. However, do note that once migrated to 3.25 or above, the save will not work correctly anymore in 3.24 and below, so backing up saves is recommended if for any reason people want to downgrade. This being said, the issues should be relatively minor, mainly user-disabled or reliability-broken PCs being forever stuck in the disabled state.

The PR implement a proper fix for issue #642 by allowing the `IConfigurable.Configure()` method to specify a multiplier for when multiple slots are assigned to the same setup. The ProcessController module then implement proper handling of the multiplier by applying it to the pseudo-resource amount/maxAmount in its `IConfigurable.Configure()` implementation.

Due to the changes being somehwat risky, this should probably be playtested a bit before merging/releasing. 

Dev builds (remember to backup your save as it won't be compatible with 3.24 anymore) :
[Kerbalism-Core_dev-9386_for_KSP1.8.0-1.12.9.zip](https://github.com/user-attachments/files/22296982/Kerbalism-Core_dev-9386_for_KSP1.8.0-1.12.9.zip)
[Kerbalism-Config_dev-9386_for_KSP1.8.0-1.12.9.zip](https://github.com/user-attachments/files/22296957/Kerbalism-Config_dev-9386_for_KSP1.8.0-1.12.9.zip)