### PR TITLE
Improve partmodule caching

### DIFF
--- a/src/Kerbalism/Automation/Computer.cs
+++ b/src/Kerbalism/Automation/Computer.cs
@@ -241,8 +241,9 @@ namespace KERBALISM
 			// loaded vessel
 			if (v.loaded)
 			{
-				foreach (PartModule m in Lib.FindModules<PartModule>(v))
+				foreach (PartModule m in PartModuleCache.GetModules<PartModule>(v))
 				{
+					if (!m.isEnabled) continue;
 					switch (m.moduleName)
 					{
 						case "ProcessController":            device = new ProcessDevice(m as ProcessController);                 break;

--- a/src/Kerbalism/Cache.cs
+++ b/src/Kerbalism/Cache.cs
@@ -10,12 +10,16 @@ namespace KERBALISM
 		public static void Init()
 		{
 			vesselObjects = new Dictionary<Guid, Dictionary<string, object>>();
+			PartModuleCache.Clear();
+			ProtoPartModuleCache.Clear();
 		}
 
 
 		public static void Clear()
 		{
 			vesselObjects.Clear();
+			PartModuleCache.Clear();
+			ProtoPartModuleCache.Clear();
 		}
 
 		/// <summary>
@@ -26,6 +30,8 @@ namespace KERBALISM
 		{
 			var id = Lib.VesselID(v);
 			vesselObjects.Remove(id);
+			PartModuleCache.Purge(id);
+			ProtoPartModuleCache.Purge(id);
 		}
 
 		/// <summary>
@@ -36,6 +42,8 @@ namespace KERBALISM
 		{
 			var id = Lib.VesselID(v);
 			vesselObjects.Remove(id);
+			PartModuleCache.Purge(id);
+			ProtoPartModuleCache.Purge(id);
 		}
 
 		/// <summary>
@@ -45,6 +53,8 @@ namespace KERBALISM
 		public static void PurgeAllCaches()
 		{
 			vesselObjects.Clear();
+			PartModuleCache.Clear();
+			ProtoPartModuleCache.Clear();
 			Message.all_logs.Clear();
 		}
 

--- a/src/Kerbalism/Database/ReliabilityInfo.cs
+++ b/src/Kerbalism/Database/ReliabilityInfo.cs
@@ -91,8 +91,9 @@ namespace KERBALISM
 
 			if (vessel.loaded)
 			{
-				foreach (var r in Lib.FindModules<Reliability>(vessel))
+				foreach (var r in PartModuleCache.GetModules<Reliability>(vessel))
 				{
+					if (!r.isEnabled) continue;
 					result.Add(new ReliabilityInfo(r));
 				}
 			}

--- a/src/Kerbalism/Kerbalism.csproj
+++ b/src/Kerbalism/Kerbalism.csproj
@@ -126,6 +126,8 @@
     <Compile Include="Automation\VesselDevices\VesselTransmit.cs" />
     <Compile Include="Background.cs" />
     <Compile Include="Cache.cs" />
+    <Compile Include="PartModuleCache.cs" />
+    <Compile Include="ProtoPartModuleCache.cs" />
     <Compile Include="Automation\Devices\Converter.cs" />
     <Compile Include="Automation\Devices\Drill.cs" />
     <Compile Include="Automation\Devices\Emitter.cs" />

--- a/src/Kerbalism/Lib.cs
+++ b/src/Kerbalism/Lib.cs
@@ -2373,29 +2373,6 @@ namespace KERBALISM
 		#endregion
 
 		#region MODULE
-		///<summary>
-		/// return all modules implementing a specific type in a vessel
-		/// note: disabled modules are not returned
-		/// </summary>
-		public static List<T> FindModules<T>(Vessel v) where T : class
-		{
-			List<T> ret = new List<T>();
-			for (int i = 0; i < v.parts.Count; ++i)
-			{
-				Part p = v.parts[i];
-				for (int j = 0; j < p.Modules.Count; ++j)
-				{
-					PartModule m = p.Modules[j];
-					if (m.isEnabled)
-					{
-						if (m is T t)
-							ret.Add(t);
-					}
-				}
-			}
-			return ret;
-		}
-
 		public static bool HasPart(Vessel v, string part_name)
 		{
 			if (Cache.HasVesselObjectsCache(v, "has_part:" + part_name))
@@ -2412,27 +2389,6 @@ namespace KERBALISM
 			}
 
 			Cache.SetVesselObjectsCache(v, "has_part:" + part_name, ret);
-			return ret;
-		}
-
-		/// <summary>
-		/// return all proto modules with a specified name in a vessel.
-		/// note: disabled modules are not returned
-		/// </summary>
-		public static List<ProtoPartModuleSnapshot> FindModules(ProtoVessel v, string module_name)
-		{
-			var ret = Cache.VesselObjectsCache<List<ProtoPartModuleSnapshot>>(v, "mod:" + module_name);
-			if (ret != null)
-				return ret;
-
-			ret = new List<ProtoPartModuleSnapshot>(8);
-			for (int i = 0; i < v.protoPartSnapshots.Count; ++i)
-			{
-				ProtoPartSnapshot p = v.protoPartSnapshots[i];
-				ret.AddRange(FindModules(p, module_name));
-			}
-
-			Cache.SetVesselObjectsCache(v, "mod:" + module_name, ret);
 			return ret;
 		}
 
@@ -2460,39 +2416,28 @@ namespace KERBALISM
 		///</summary>
 		public static bool HasModule<T>(Vessel v, Predicate<T> filter) where T : class
 		{
-			for (int i = 0; i < v.parts.Count; ++i)
+			List<T> modules = PartModuleCache.GetModules<T>(v);
+			for (int i = 0; i < modules.Count; ++i)
 			{
-				Part p = v.parts[i];
-				for (int j = 0; j < p.Modules.Count; ++j)
-				{
-					PartModule m = p.Modules[j];
-					if (m.isEnabled)
-					{
-						if (m is T t && filter(t))
-							return true;
-					}
-				}
+				T t = modules[i];
+				if ((t as PartModule).isEnabled && filter(t))
+					return true;
 			}
 			return false;
 		}
 
 		///<summary>
 		/// return true if a proto module with the specified name and satisfying the predicate specified exist in a vessel
-		///note: disabled modules are not returned
+		/// note: disabled modules are ignored
+		/// note: the module list is cached per-vessel (see ProtoPartModuleCache), the predicate is evaluated on every call
 		///</summary>
 		public static bool HasModule(ProtoVessel v, string module_name, Predicate<ProtoPartModuleSnapshot> filter)
 		{
-			for (int i = 0; i < v.protoPartSnapshots.Count; ++i)
+			List<ProtoPartModuleSnapshot> modules = ProtoPartModuleCache.GetModules(v, module_name);
+			for (int i = 0; i < modules.Count; ++i)
 			{
-				ProtoPartSnapshot p = v.protoPartSnapshots[i];
-				for (int j = 0; j < p.modules.Count; ++j)
-				{
-					ProtoPartModuleSnapshot m = p.modules[j];
-					if (m.moduleName == module_name && Proto.GetBool(m, "isEnabled") && filter(m))
-					{
-						return true;
-					}
-				}
+				if (filter(modules[i]))
+					return true;
 			}
 			return false;
 		}
@@ -2901,7 +2846,7 @@ namespace KERBALISM
 				if (v.loaded)
 				{
 					// get all science containers/experiments with data
-					List<IScienceDataContainer> modules = Lib.FindModules<IScienceDataContainer>( v ).FindAll( k => k.GetData().Length > 0 );
+					List<IScienceDataContainer> modules = PartModuleCache.GetModules<IScienceDataContainer>( v ).FindAll( k => (k as PartModule).isEnabled && k.GetData().Length > 0 );
 
 					// remove a data sample at random
 					if (modules.Count > 0)
@@ -2916,8 +2861,8 @@ namespace KERBALISM
 				{
 					// get all science containers/experiments with data
 					var modules = new List<ProtoPartModuleSnapshot>();
-					modules.AddRange( Lib.FindModules( v.protoVessel, "ModuleScienceContainer" ).FindAll( k => k.moduleValues.GetNodes( "ScienceData" ).Length > 0 ) );
-					modules.AddRange( Lib.FindModules( v.protoVessel, "ModuleScienceExperiment" ).FindAll( k => k.moduleValues.GetNodes( "ScienceData" ).Length > 0 ) );
+					modules.AddRange( ProtoPartModuleCache.GetModules( v.protoVessel, "ModuleScienceContainer" ).FindAll( k => k.moduleValues.GetNodes( "ScienceData" ).Length > 0 ) );
+					modules.AddRange( ProtoPartModuleCache.GetModules( v.protoVessel, "ModuleScienceExperiment" ).FindAll( k => k.moduleValues.GetNodes( "ScienceData" ).Length > 0 ) );
 
 					// remove a data sample at random
 					if (modules.Count > 0)

--- a/src/Kerbalism/Modules/Comfort.cs
+++ b/src/Kerbalism/Modules/Comfort.cs
@@ -47,52 +47,53 @@ namespace KERBALISM
 		{
 			// environment factors
 			firm_ground = env_firm_ground;
-			try
-			{
-				if (Lib.CrewCount(v.protoVessel) > 1)
-				{
-					this.not_alone = true;
-				}
-				else
-				{
-					this.not_alone = false;
-				}
-			}
-			catch
-			{
-				this.not_alone = env_not_alone;
-			}
 			call_home = env_call_home;
 
-			// scan parts for comfort
-			foreach (ProtoPartModuleSnapshot m in Lib.FindModules(v.protoVessel, "Comfort"))
+			if (v.loaded)
 			{
-				switch (Lib.Proto.GetString(m, "bonus"))
+				not_alone = env_not_alone;
+				bool multiCrew = Lib.CrewCount(v) > 1;
+
+				// scan parts for comfort
+				foreach (Comfort c in PartModuleCache.GetModules<Comfort>(v))
 				{
-					case "firm-ground": firm_ground = true; break;
-					case "not-alone": not_alone = (Lib.CrewCount(v.protoVessel) > 1); break;
-					case "call-home": call_home = true; break;
-					case "exercise": exercise = true; break;
-					case "panorama": panorama = true; break;
-					case "plants": plants = true; break;
+					if (c.isEnabled)
+						ApplyBonus(c.bonus, multiCrew);
+				}
+
+				// scan parts for gravity ring
+				if (Lib.IsPowered(v))
+				{
+					firm_ground |= Lib.HasModule<GravityRing>(v, k => k.deployed);
 				}
 			}
+			else
+			{
+				bool multiCrew;
+				try
+				{
+					multiCrew = Lib.CrewCount(v.protoVessel) > 1;
+				}
+				catch
+				{
+					multiCrew = env_not_alone;
+				}
+				not_alone = multiCrew;
 
-			// scan parts for gravity ring
-			if (Lib.IsPowered(v))
+				// scan parts for comfort
+				foreach (ProtoPartModuleSnapshot m in ProtoPartModuleCache.GetModules(v.protoVessel, "Comfort"))
+				{
+					ApplyBonus(Lib.Proto.GetString(m, "bonus"), multiCrew);
+				}
+
+				// scan parts for gravity ring
+				if (Lib.IsPowered(v))
 				{
 					firm_ground |= Lib.HasModule(v.protoVessel, "GravityRing", k => Lib.Proto.GetBool(k, "deployed"));
 				}
+			}
 
-			// calculate factor
-			factor = 0.1;
-			if (firm_ground) factor += PreferencesComfort.Instance.firmGround;
-			if (not_alone) factor += PreferencesComfort.Instance.notAlone;
-			if (call_home) factor += PreferencesComfort.Instance.callHome;
-			if (exercise) factor += PreferencesComfort.Instance.exercise;
-			if (panorama) factor += PreferencesComfort.Instance.panorama;
-			if (plants) factor += PreferencesComfort.Instance.plants;
-			factor = Lib.Clamp(factor, 0.1, 1.0);
+			CalculateFactor();
 		}
 
 
@@ -113,18 +114,10 @@ namespace KERBALISM
 					if (!m.isEnabled) continue;
 
 					// comfort
-					if (m.moduleName == "Comfort") 
+					// note: this runs in the editor where modules have no vessel, env_not_alone already is the crew count check
+					if (m.moduleName == "Comfort")
 					{
-						Comfort c = m as Comfort;
-						switch (c.bonus)
-						{
-							case "firm-ground": firm_ground = true; break;
-							case "not-alone": not_alone = (Lib.CrewCount(c.vessel) > 1); break;
-							case "call-home": call_home = true; break;
-							case "exercise": exercise = true; break;
-							case "panorama": panorama = true; break;
-							case "plants": plants = true; break;
-						}
+						ApplyBonus((m as Comfort).bonus, env_not_alone);
 					}
 					// gravity ring
 					// - ignoring if ec is present or not here
@@ -137,6 +130,26 @@ namespace KERBALISM
 			}
 
 			// calculate factor
+			CalculateFactor();
+		}
+
+		///<summary>register the bonus provided by a comfort provider</summary>
+		private void ApplyBonus(string bonus, bool multiCrew)
+		{
+			switch (bonus)
+			{
+				case "firm-ground": firm_ground = true; break;
+				case "not-alone": not_alone = multiCrew; break;
+				case "call-home": call_home = true; break;
+				case "exercise": exercise = true; break;
+				case "panorama": panorama = true; break;
+				case "plants": plants = true; break;
+			}
+		}
+
+		///<summary>compute the comfort factor from the individual bonuses</summary>
+		private void CalculateFactor()
+		{
 			factor = 0.1;
 			if (firm_ground) factor += PreferencesComfort.Instance.firmGround;
 			if (not_alone) factor += PreferencesComfort.Instance.notAlone;
@@ -146,8 +159,6 @@ namespace KERBALISM
 			if (plants) factor += PreferencesComfort.Instance.plants;
 			factor = Lib.Clamp(factor, 0.1, 1.0);
 		}
-
-
 
 		public string Tooltip()
 		{

--- a/src/Kerbalism/Modules/Emitter.cs
+++ b/src/Kerbalism/Modules/Emitter.cs
@@ -239,8 +239,9 @@ namespace KERBALISM
 				var vd = n.KerbalismData();
 				if (!vd.IsSimulated) continue;
 
-				foreach (var emitter in Lib.FindModules<Emitter>(n))
+				foreach (var emitter in PartModuleCache.GetModules<Emitter>(n))
 				{
+					if (!emitter.isEnabled) continue;
 					if (emitter.part == null || emitter.part.transform == null) continue;
 					if (emitter.radiation <= 0) continue; // ignore shielding effects here
 					if (!emitter.running) continue;
@@ -265,8 +266,9 @@ namespace KERBALISM
 			double tot = 0.0;
 			if (v.loaded)
 			{
-				foreach (var emitter in Lib.FindModules<Emitter>(v))
+				foreach (var emitter in PartModuleCache.GetModules<Emitter>(v))
 				{
+					if (!emitter.isEnabled) continue;
 					if (ec.Amount > double.Epsilon || emitter.ec_rate <= double.Epsilon)
 					{
 						if (emitter.running)
@@ -279,7 +281,7 @@ namespace KERBALISM
 			}
 			else
 			{
-				foreach (ProtoPartModuleSnapshot m in Lib.FindModules(v.protoVessel, "Emitter"))
+				foreach (ProtoPartModuleSnapshot m in ProtoPartModuleCache.GetModules(v.protoVessel, "Emitter"))
 				{
 					if (ec.Amount > double.Epsilon || Lib.Proto.GetDouble(m, "ec_rate") <= double.Epsilon)
 					{

--- a/src/Kerbalism/Modules/Greenhouse.cs
+++ b/src/Kerbalism/Modules/Greenhouse.cs
@@ -518,9 +518,9 @@ namespace KERBALISM
 			List<Data> ret = new List<Data>();
 			if (v.loaded)
 			{
-				foreach (Greenhouse greenhouse in Lib.FindModules<Greenhouse>(v))
+				foreach (Greenhouse greenhouse in PartModuleCache.GetModules<Greenhouse>(v))
 				{
-					if (greenhouse.active)
+					if (greenhouse.isEnabled && greenhouse.active)
 					{
 						Data gd = new Data
 						{
@@ -536,7 +536,7 @@ namespace KERBALISM
 			}
 			else
 			{
-				foreach (ProtoPartModuleSnapshot m in Lib.FindModules(v.protoVessel, "Greenhouse"))
+				foreach (ProtoPartModuleSnapshot m in ProtoPartModuleCache.GetModules(v.protoVessel, "Greenhouse"))
 				{
 					if (Lib.Proto.GetBool(m, "active"))
 					{

--- a/src/Kerbalism/Modules/Laboratory.cs
+++ b/src/Kerbalism/Modules/Laboratory.cs
@@ -329,7 +329,7 @@ namespace KERBALISM
 			}
 			else // unloaded vessel
 			{
-				foreach (ProtoPartModuleSnapshot m in Lib.FindModules(v.protoVessel, "Experiment"))
+				foreach (ProtoPartModuleSnapshot m in ProtoPartModuleCache.GetModules(v.protoVessel, "Experiment"))
 				{
 					restoredAmount -= Experiment.RestoreSampleMass(restoredAmount, m, filename.ExpInfo.ExperimentId);
 					if (restoredAmount < double.Epsilon) return;

--- a/src/Kerbalism/Modules/PassiveShield.cs
+++ b/src/Kerbalism/Modules/PassiveShield.cs
@@ -175,8 +175,9 @@ namespace KERBALISM
 			double total = 0.0;
 			if (v.loaded)
 			{
-				foreach (var shield in Lib.FindModules<PassiveShield>(v))
+				foreach (var shield in PartModuleCache.GetModules<PassiveShield>(v))
 				{
+					if (!shield.isEnabled) continue;
 					if (ec.Amount > 0 || shield.ec_rate <= 0)
 					{
 						if (shield.deployed)
@@ -186,7 +187,7 @@ namespace KERBALISM
 			}
 			else
 			{
-				foreach (ProtoPartModuleSnapshot m in Lib.FindModules(v.protoVessel, "PassiveShield"))
+				foreach (ProtoPartModuleSnapshot m in ProtoPartModuleCache.GetModules(v.protoVessel, "PassiveShield"))
 				{
 					if (ec.Amount > 0 || Lib.Proto.GetDouble(m, "ec_rate") <= 0)
 					{

--- a/src/Kerbalism/Modules/Reliability.cs
+++ b/src/Kerbalism/Modules/Reliability.cs
@@ -753,6 +753,8 @@ namespace KERBALISM
 						Lib.Proto.Set(proto_module, nameof(ProcessController.broken), true);
 				}
 
+				ProtoPartModuleCache.Purge(Lib.VesselID(v));
+
 				// type-specific hacks
 				switch (reliability.type)
 				{
@@ -997,9 +999,9 @@ namespace KERBALISM
 		{
 			if (v.loaded)
 			{
-				foreach (Reliability m in Lib.FindModules<Reliability>(v))
+				foreach (Reliability m in PartModuleCache.GetModules<Reliability>(v))
 				{
-					if (m.redundancy == redundancy)
+					if (m.isEnabled && m.redundancy == redundancy)
 					{
 						m.next += m.next - m.last;
 					}
@@ -1099,7 +1101,7 @@ namespace KERBALISM
 			if (v.loaded)
 			{
 				// choose a module at random
-				var modules = Lib.FindModules<Reliability>(v).FindAll(k => !k.broken);
+				var modules = PartModuleCache.GetModules<Reliability>(v).FindAll(k => k.isEnabled && !k.broken);
 				if (modules.Count == 0) return;
 				var m = modules[Lib.RandomInt(modules.Count)];
 
@@ -1110,7 +1112,7 @@ namespace KERBALISM
 			else
 			{
 				// choose a module at random
-				var modules = Lib.FindModules(v.protoVessel, "Reliability").FindAll(k => !Lib.Proto.GetBool(k, "broken"));
+				var modules = ProtoPartModuleCache.GetModules(v.protoVessel, "Reliability").FindAll(k => !Lib.Proto.GetBool(k, "broken"));
 				if (modules.Count == 0) return;
 				var m = modules[Lib.RandomInt(modules.Count)];
 
@@ -1145,7 +1147,7 @@ namespace KERBALISM
 
 			if (v.loaded)
 			{
-				foreach (Reliability m in Lib.FindModules<Reliability>(v))
+				foreach (Reliability m in PartModuleCache.GetModules<Reliability>(v))
 				{
 					malfunction |= m.broken;
 					critical |= m.critical;
@@ -1153,7 +1155,7 @@ namespace KERBALISM
 			}
 			else
 			{
-				foreach (ProtoPartModuleSnapshot m in Lib.FindModules(v.protoVessel, "Reliability"))
+				foreach (ProtoPartModuleSnapshot m in ProtoPartModuleCache.GetModules(v.protoVessel, "Reliability"))
 				{
 					malfunction |= Lib.Proto.GetBool(m, "broken");
 					critical |= Lib.Proto.GetBool(m, "critical");

--- a/src/Kerbalism/PartModuleCache.cs
+++ b/src/Kerbalism/PartModuleCache.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace KERBALISM
+{
+	///<summary>
+	/// Per-vessel cache of loaded PartModules, bucketed by queried type and built lazily
+	/// in a single parts/modules pass per queried type. The returned lists are cached and shared :
+	/// - never modify them
+	/// - they include disabled modules : check isEnabled at use time (Configure toggles
+	///   isEnabled at runtime without firing any vessel-modified event)
+	/// <para/>
+	/// Validity is self-checked against the vessel part list : KSP creates a new parts list
+	/// instance on vessel load (Vessel.StartFromBackup), so stale module references can't leak
+	/// across an unload/reload cycle even if no purge event fired. Structural changes while
+	/// loaded are caught by the part count check, and trough Cache.PurgeVesselCaches() which
+	/// is called on all the vessel-modified game events.
+	///</summary>
+	public static class PartModuleCache
+	{
+		private sealed class Entry
+		{
+			public List<Part> partsRef;	// v.parts instance at build time
+			public int partCount;		// v.parts.Count at build time
+			public readonly Dictionary<Type, IList> byType = new Dictionary<Type, IList>();
+		}
+
+		private static readonly Dictionary<Guid, Entry> entries = new Dictionary<Guid, Entry>();
+
+		///<summary>
+		/// return all partmodules implementing a specific type on a loaded vessel.
+		/// note: disabled modules are returned, check isEnabled on each module.
+		/// note: the returned list is cached and shared, do not modify it.
+		///</summary>
+		public static List<T> GetModules<T>(Vessel v) where T : class
+		{
+			Guid id = Lib.VesselID(v);
+
+			Entry e;
+			if (!entries.TryGetValue(id, out e)
+				|| !ReferenceEquals(e.partsRef, v.parts)
+				|| e.partCount != v.parts.Count)
+			{
+				e = new Entry { partsRef = v.parts, partCount = v.parts.Count };
+				entries[id] = e;
+			}
+
+			IList cached;
+			if (e.byType.TryGetValue(typeof(T), out cached))
+				return (List<T>)cached;
+
+			List<T> result = new List<T>();
+			for (int i = 0; i < v.parts.Count; ++i)
+			{
+				Part p = v.parts[i];
+				for (int j = 0; j < p.Modules.Count; ++j)
+				{
+					if (p.Modules[j] is T t)
+						result.Add(t);
+				}
+			}
+			e.byType.Add(typeof(T), result);
+			return result;
+		}
+
+		///<summary>forget the cached module lists of a vessel</summary>
+		public static void Purge(Guid id)
+		{
+			entries.Remove(id);
+		}
+
+		///<summary>forget the cached module lists of all vessels</summary>
+		public static void Clear()
+		{
+			entries.Clear();
+		}
+	}
+}

--- a/src/Kerbalism/ProtoPartModuleCache.cs
+++ b/src/Kerbalism/ProtoPartModuleCache.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+
+namespace KERBALISM
+{
+	///<summary>
+	/// Per-vessel cache of ProtoPartModuleSnapshots, bucketed by queried module name and built
+	/// lazily in a single parts/modules pass per queried name. The returned lists are cached and
+	/// shared :
+	/// - never modify them
+	/// - disabled modules are not included
+	/// <para/>
+	/// Validity is self-checked against the ProtoVessel instance : KSP rebuilds the whole proto
+	/// snapshot hierarchy of loaded vessels on every backup (Vessel.BackupVessel, called on game
+	/// saves) without firing any vessel-modified event, so a new ProtoVessel instance can't serve
+	/// stale module references. Structural changes are caught trough Cache.PurgeVesselCaches()
+	/// which is called on all the vessel-modified game events.
+	///</summary>
+	public static class ProtoPartModuleCache
+	{
+		private sealed class Entry
+		{
+			public ProtoVessel protoRef;	// ProtoVessel instance at build time
+			public readonly Dictionary<string, List<ProtoPartModuleSnapshot>> byName = new Dictionary<string, List<ProtoPartModuleSnapshot>>();
+		}
+
+		// vessel ID -> cache entry
+		private static readonly Dictionary<Guid, Entry> entries = new Dictionary<Guid, Entry>();
+
+		///<summary>
+		/// return all proto modules with a specified name on a vessel.
+		/// note: disabled modules are not returned.
+		/// note: the returned list is cached and shared, do not modify it.
+		///</summary>
+		public static List<ProtoPartModuleSnapshot> GetModules(ProtoVessel v, string module_name)
+		{
+			Guid id = Lib.VesselID(v);
+
+			Entry e;
+			if (!entries.TryGetValue(id, out e) || !ReferenceEquals(e.protoRef, v))
+			{
+				e = new Entry { protoRef = v };
+				entries[id] = e;
+			}
+
+			List<ProtoPartModuleSnapshot> result;
+			if (e.byName.TryGetValue(module_name, out result))
+				return result;
+
+			result = new List<ProtoPartModuleSnapshot>(8);
+			for (int i = 0; i < v.protoPartSnapshots.Count; ++i)
+			{
+				ProtoPartSnapshot p = v.protoPartSnapshots[i];
+				for (int j = 0; j < p.modules.Count; ++j)
+				{
+					ProtoPartModuleSnapshot m = p.modules[j];
+					if (m.moduleName == module_name && Lib.Proto.GetBool(m, "isEnabled"))
+						result.Add(m);
+				}
+			}
+			e.byName.Add(module_name, result);
+			return result;
+		}
+
+		///<summary>forget the cached module lists of a vessel</summary>
+		public static void Purge(Guid id)
+		{
+			entries.Remove(id);
+		}
+
+		///<summary>forget the cached module lists of all vessels</summary>
+		public static void Clear()
+		{
+			entries.Clear();
+		}
+	}
+}

--- a/src/Kerbalism/Science/ExperimentRequirements.cs
+++ b/src/Kerbalism/Science/ExperimentRequirements.cs
@@ -257,7 +257,7 @@ namespace KERBALISM
 				case Require.Magnetosphere: reqResult = vd.EnvMagnetosphere                                  ? 1.0 : 0.0; break;
 				case Require.InterStellar : reqResult = Lib.IsSun(v.mainBody) && vd.EnvInterstellar          ? 1.0 : 0.0; break;
 				case Require.Part         : reqResult = Lib.HasPart(v, (string)rv)                           ? 1.0 : 0.0; break;
-				case Require.Module       : reqResult = Lib.FindModules(v.protoVessel, (string)rv).Count > 0 ? 1.0 : 0.0; break;
+				case Require.Module       : reqResult = ProtoPartModuleCache.GetModules(v.protoVessel, (string)rv).Count > 0 ? 1.0 : 0.0; break;
 
 				default: reqResult = 1.0; break;
 			}

--- a/src/Kerbalism/System/Callbacks.cs
+++ b/src/Kerbalism/System/Callbacks.cs
@@ -98,6 +98,13 @@ namespace KERBALISM
 			GameEvents.onVesselChange.Add((v) => { OnVesselModified(v); });
 			GameEvents.onVesselStandardModification.Add((v) => { OnVesselStandardModification(v); });
 
+			// the cached loaded PartModule lists and protoVessel module snapshot lists must not
+			// survive load/unload transitions : Vessel.Unload() replaces the protoVessel instance
+			// (so cached snapshot references would write to dead objects), and loading a vessel
+			// recreates all PartModules. None of the vessel-modified events fire on these transitions.
+			GameEvents.onVesselLoaded.Add((v) => Cache.PurgeVesselCaches(v));
+			GameEvents.onVesselUnloaded.Add((v) => Cache.PurgeVesselCaches(v));
+
 			GameEvents.OnTechnologyResearched.Add(this.TechResearched);
 			GameEvents.onGUIEditorToolbarReady.Add(this.AddEditorCategory);
 

--- a/src/Kerbalism/System/Kerbalism.cs
+++ b/src/Kerbalism/System/Kerbalism.cs
@@ -101,6 +101,10 @@ namespace KERBALISM
 		private void OnDestroy()
 		{
 			Fetch = null;
+
+			// better to clear the caches during scene switch so that GC can clean up early, instead of waiting for the next OnLoad() call
+			Cache.Clear();
+			ResourceCache.Clear();
 		}
 
 		public override void OnLoad(ConfigNode node)

--- a/src/Kerbalism/UI/Telemetry.cs
+++ b/src/Kerbalism/UI/Telemetry.cs
@@ -60,14 +60,15 @@ namespace KERBALISM
 			HashSet<string> readings = new HashSet<string>();
 			if (v.loaded)
 			{
-				foreach (var s in Lib.FindModules<Sensor>(v))
+				foreach (var s in PartModuleCache.GetModules<Sensor>(v))
 				{
+					if (s.isEnabled)
 					readings.Add(s.type);
 				}
 			}
 			else
 			{
-				foreach (ProtoPartModuleSnapshot m in Lib.FindModules(v.protoVessel, "Sensor"))
+				foreach (ProtoPartModuleSnapshot m in ProtoPartModuleCache.GetModules(v.protoVessel, "Sensor"))
 				{
 					readings.Add(Lib.Proto.GetString(m, "type"));
 				}


### PR DESCRIPTION
Add a separate cache for fetching partmodules on loaded vessels.
We already had caching for protovessels but that was kinda mixed into the Lib class. Now it is a separate entity and as such - no longer needs to allocate unique keys for the generic cache (`"mod:" + module_name`).