### PR TITLE
Fix excessive EC drain when transmitting experiments

### DIFF
--- a/src/Kerbalism/Modules/Experiment.cs
+++ b/src/Kerbalism/Modules/Experiment.cs
@@ -283,7 +283,8 @@ namespace KERBALISM
 			if (Lib.IsFlight())
 			{
 				VesselData vd = vessel.KerbalismData();
-				if (!vd.IsSimulated) return;
+				if (!vd.IsSimulated)
+					return;
 
 				if (prepare_cs == null || didPrepare || (hide_when_unavailable && status != ExpStatus.Issue))
 				{
@@ -325,7 +326,7 @@ namespace KERBALISM
 			}
 		}
 
-		public virtual void FixedUpdate()
+		public void ForegroundFixedUpdate()
 		{
 			Profiler.BeginSample("Kerbalism.Experiment.FixedUpdate");
 
@@ -351,6 +352,7 @@ namespace KERBALISM
 				if (subject == null)
 				{
 					vd.IsSimulated = vd.CheckIfSimulated();
+					Profiler.EndSample();
 					return;
 				}
 				Profiler.EndSample();
@@ -364,10 +366,12 @@ namespace KERBALISM
 				if (subject == null)
 				{
 					vd.IsSimulated = vd.CheckIfSimulated();
+					Profiler.EndSample();
 					return;
 				}
-				Profiler.EndSample();
+
 				Toggle();
+				Profiler.EndSample();
 				return;
 			}
 
@@ -389,9 +393,11 @@ namespace KERBALISM
 				null);
 			Profiler.EndSample();
 
+			Profiler.BeginSample("Experiment.FixedUpdate.Notify");
 			var newStatus = GetStatus(expState, subject, issue);
 			API.OnExperimentStateChanged.Notify(vessel, experiment_id, status, newStatus);
 			status = newStatus;
+			Profiler.EndSample();
 
 			Profiler.EndSample();
 		}

--- a/src/Kerbalism/System/Kerbalism.cs
+++ b/src/Kerbalism/System/Kerbalism.cs
@@ -318,7 +318,7 @@ namespace KERBALISM
 				// if loaded
 				if (v.loaded)
 				{
-					Profiler.BeginSample("Loaded.VesselDataEval");
+					Profiler.BeginSample("Kerbalism.Loaded.VesselDataEval");
 					// update the vessel info
 					vd.Evaluate(false, elapsed_s);
 					Profiler.EndSample();
@@ -326,7 +326,7 @@ namespace KERBALISM
 					// get most used resource
 					ResourceInfo ec = resources.GetResource(v, "ElectricCharge");
 
-					Profiler.BeginSample("Loaded.Radiation");
+					Profiler.BeginSample("Kerbalism.Loaded.Radiation");
 					// show belt warnings
 					Radiation.BeltWarnings(v, vd);
 
@@ -334,26 +334,33 @@ namespace KERBALISM
 					Storm.Update(v, vd, elapsed_s);
 					Profiler.EndSample();
 
-					Profiler.BeginSample("Loaded.Comms");
+					Profiler.BeginSample("Kerbalism.Loaded.Comms");
 					CommsMessages.Update(v, vd, elapsed_s);
 					Profiler.EndSample();
 
-					Profiler.BeginSample("Loaded.Science");
+					Profiler.BeginSample("Kerbalism.Loaded.Experiment");
+					foreach(Experiment e in PartModuleCache.GetModules<Experiment>(v))
+					{
+						e.ForegroundFixedUpdate();
+					}
+					Profiler.EndSample();
+
+					Profiler.BeginSample("Kerbalism.Loaded.Science");
 					// transmit science data
 					Science.Update(v, vd, ec, elapsed_s);
 					Profiler.EndSample();
 
-					Profiler.BeginSample("Loaded.Profile");
+					Profiler.BeginSample("Kerbalism.Loaded.Profile");
 					// apply rules
 					Profile.Execute(v, vd, resources, elapsed_s);
 					Profiler.EndSample();
 
-					Profiler.BeginSample("Loaded.ResourceUpdate");
+					Profiler.BeginSample("Kerbalism.Loaded.ResourceUpdate");
 					// part module resource updates
 					vd.ResourceUpdate(resources, elapsed_s);
 					Profiler.EndSample(); 
 
-					Profiler.BeginSample("Loaded.Resource");
+					Profiler.BeginSample("Kerbalism.Loaded.Resource");
 					// apply deferred requests
 					resources.Sync(v, vd, elapsed_s);
 					Profiler.EndSample();
@@ -402,7 +409,7 @@ namespace KERBALISM
 				// get most used resource
 				ResourceInfo last_ec = last_resources.GetResource(last_v, "ElectricCharge");
 
-				Profiler.BeginSample("Unloaded.Radiation");
+				Profiler.BeginSample("Kerbalism.Unloaded.Radiation");
 				// show belt warnings
 				Radiation.BeltWarnings(last_v, last_vd);
 
@@ -410,34 +417,34 @@ namespace KERBALISM
 				Storm.Update(last_v, last_vd, last_time);
 				Profiler.EndSample();
 
-				Profiler.BeginSample("Unloaded.Comms");
+				Profiler.BeginSample("Kerbalism.Unloaded.Comms");
 				CommsMessages.Update(last_v, last_vd, last_time);
 				Profiler.EndSample();
 
-				Profiler.BeginSample("Unloaded.Background");
+				Profiler.BeginSample("Kerbalism.Unloaded.Background");
 				// simulate modules in background
 				Background.Update(last_v, last_vd, last_resources, last_time);
 				Profiler.EndSample();
 
-				Profiler.BeginSample("Unloaded.SystemHeat");
+				Profiler.BeginSample("Kerbalism.Unloaded.SystemHeat");
 				SystemHeatBackgroundThermal.TryRun(last_v, last_time);
 				Profiler.EndSample();
 
-				Profiler.BeginSample("Unloaded.FissionReactor");
+				Profiler.BeginSample("Kerbalism.Unloaded.FissionReactor");
 				SystemHeatBackgroundThermal.PrepareFrozenFissionReactors(last_v, last_time);
 				Profiler.EndSample();
 
-				Profiler.BeginSample("Unloaded.Profile");
+				Profiler.BeginSample("Kerbalism.Unloaded.Profile");
 				// apply rules
 				Profile.Execute(last_v, last_vd, last_resources, last_time);
 				Profiler.EndSample();
 
-				Profiler.BeginSample("Unloaded.Science");
+				Profiler.BeginSample("Kerbalism.Unloaded.Science");
 				// transmit science	data
 				Science.Update(last_v, last_vd, last_ec, last_time);
 				Profiler.EndSample();
 
-				Profiler.BeginSample("Unloaded.Resource");
+				Profiler.BeginSample("Kerbalism.Unloaded.Resource");
 				// apply deferred requests
 				last_resources.Sync(last_v, last_vd, last_time);
 				Profiler.EndSample();
@@ -485,7 +492,7 @@ namespace KERBALISM
 			Highlighter.Update();
 
 			// prepare gui content
-			Profiler.BeginSample("UI.Update");
+			Profiler.BeginSample("Kerbalism.UI.Update");
 			UI.Update(Callbacks.visible);
 			// KsmGui (Science Archive, etc.) ignores the IMGUI visible flag; sync its canvas
 			// so facility overlays (R&D, Admin, …) hide and restore open windows (#556).

--- a/src/Kerbalism/System/Kerbalism.cs
+++ b/src/Kerbalism/System/Kerbalism.cs
@@ -341,7 +341,8 @@ namespace KERBALISM
 					Profiler.BeginSample("Kerbalism.Loaded.Experiment");
 					foreach(Experiment e in PartModuleCache.GetModules<Experiment>(v))
 					{
-						e.ForegroundFixedUpdate();
+						if (e.isEnabled)
+							e.ForegroundFixedUpdate();
 					}
 					Profiler.EndSample();
 

--- a/src/Kerbalism/System/Kerbalism.cs
+++ b/src/Kerbalism/System/Kerbalism.cs
@@ -341,8 +341,7 @@ namespace KERBALISM
 					Profiler.BeginSample("Kerbalism.Loaded.Experiment");
 					foreach(Experiment e in PartModuleCache.GetModules<Experiment>(v))
 					{
-							if (!e.isEnabled || !e.enabled)
-								continue;
+						if (e.isEnabled)
 							e.ForegroundFixedUpdate();
 					}
 					Profiler.EndSample();

--- a/src/Kerbalism/System/Kerbalism.cs
+++ b/src/Kerbalism/System/Kerbalism.cs
@@ -341,7 +341,8 @@ namespace KERBALISM
 					Profiler.BeginSample("Kerbalism.Loaded.Experiment");
 					foreach(Experiment e in PartModuleCache.GetModules<Experiment>(v))
 					{
-						if (e.isEnabled)
+							if (!e.isEnabled || !e.enabled)
+								continue;
 							e.ForegroundFixedUpdate();
 					}
 					Profiler.EndSample();


### PR DESCRIPTION
Experiment.FixedUpdate is one cycle behind Kerbalism.FixedUpdate. 
This can cause excessive EC drain when transitioning from high bandwidth comms to very low bandwidth comms.
Experiment puts data on transmit buffer assuming a large capacity. When comms drop to very low bandwidth on the next cycle the existing data on the transmit buffer now has a very large EC cost to transmit. 4 million EC in one observed case.

Move Experiment.FixedUpdate to Kerbalism.FixedUpdate to match background experiment processing.
Also update profiler strings to aid in profiling with the Unity analyzer.

Iterating through the cached experiments took 17 us on a vessel with 36 total Experiment modules and 17 enabled Experiment modules. Of those 7 were active and waiting and took 197us for all of the fixedUpdate calls. Room for improvement here.
