### PR TITLE
Solar panel logic reverted to 3.32 via options

### DIFF
--- a/GameData/Kerbalism/Localization/de.cfg
+++ b/GameData/Kerbalism/Localization/de.cfg
@@ -913,7 +913,7 @@ Localization
     //
     #KERBALISM_Preferences_General = Allgemein // "General"
     #KERBALISM_FreezeUnloadedSolarPanelExposure = Unbeladene Solarpaneel-Exposition einfrieren // "Freeze Unloaded Solar Exposure"
-    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = Entladene Schiffe im Orbit behalten bei niedriger Zeitbeschleunigung die Sonnenexposition der Solarpaneele vom Umschalten aus dem beladenen Zustand; im Schatten bleibt die Ausgabe null. Der analytische Hochgeschwindigkeitsmodus bleibt unverändert. // "Unloaded in-space vessels at low timewarp keep sunlit solar-panel exposure from the loaded→unloaded transition; shadow still zeros output. High-warp analytic is unchanged."
+    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = Schiffe im Orbit behalten die Sonnenexposition der Solarpaneele aus der letzten Echtzeit-Auswertung (beladen bei hoher Zeitbeschleunigung oder entladen). Im Schatten bei niedriger Zeitbeschleunigung bleibt die Ausgabe null; der analytische Modus wendet weiterhin den Bahn-Sonnenanteil an. Deaktivieren, um die Ausrichtung im entladenen oder analytischen Zustand neu zu berechnen. // "In-space vessels keep sunlit solar-panel exposure from the last realtime evaluation (loaded high-warp or unloaded). Low-warp shadow still zeros output; analytic still applies the orbit sunlight fraction. Disable to recalculate panel facing while unloaded or in analytic warp."
     //
     #KERBALISM_Preferences_Science = Wissenschaft // "Science"
     #KERBALISM_TransmitScienceImmediately = Wissenschaft sofort übertragen // "Transmit Science Immediately"

--- a/GameData/Kerbalism/Localization/en-us.cfg
+++ b/GameData/Kerbalism/Localization/en-us.cfg
@@ -913,7 +913,7 @@ Localization
     //
     #KERBALISM_Preferences_General = General
     #KERBALISM_FreezeUnloadedSolarPanelExposure = Freeze Unloaded Solar Exposure
-    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = Unloaded in-space vessels at low timewarp keep sunlit solar-panel exposure from the loaded→unloaded transition; shadow still zeros output. High-warp analytic is unchanged.
+    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = In-space vessels keep sunlit solar-panel exposure from the last realtime evaluation (loaded high-warp or unloaded). Low-warp shadow still zeros output; analytic still applies the orbit sunlight fraction. Disable to recalculate panel facing while unloaded or in analytic warp.
     //
     #KERBALISM_Preferences_Science = Science
     #KERBALISM_TransmitScienceImmediately = Transmit Science Immediately

--- a/GameData/Kerbalism/Localization/es-es.cfg
+++ b/GameData/Kerbalism/Localization/es-es.cfg
@@ -913,7 +913,7 @@ Localization
     //
     #KERBALISM_Preferences_General = General
     #KERBALISM_FreezeUnloadedSolarPanelExposure = Congelar exposición solar sin cargar
-    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = Las naves en órbita sin cargar a baja aceleración temporal mantienen la exposición solar de los paneles del momento de descarga; en sombra la salida sigue siendo cero. El modo analítico a alta aceleración no cambia.
+    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = Las naves en órbita mantienen la exposición solar de los paneles de la última evaluación en tiempo real (cargadas a alta aceleración o sin cargar). En sombra a baja aceleración la salida sigue siendo cero; el modo analítico sigue aplicando la fracción de luz orbital. Desactivar para recalcular la orientación sin cargar o en modo analítico.
     //
     #KERBALISM_Preferences_Science = Ciencia
     #KERBALISM_TransmitScienceImmediately = Transmitir ciencia inmediatamente

--- a/GameData/Kerbalism/Localization/fr-fr.cfg
+++ b/GameData/Kerbalism/Localization/fr-fr.cfg
@@ -913,7 +913,7 @@ Localization
     //
     #KERBALISM_Preferences_General = Général // "General"
     #KERBALISM_FreezeUnloadedSolarPanelExposure = Geler l'exposition solaire hors chargement // "Freeze Unloaded Solar Exposure"
-    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = Les vaisseaux en orbite non chargés à faible accélération temporelle conservent l'exposition solaire des panneaux au moment du passage hors chargement ; l'ombre remet toujours la sortie à zéro. Le mode analytique à haute accélération n'est pas modifié. // "Unloaded in-space vessels at low timewarp keep sunlit solar-panel exposure from the loaded→unloaded transition; shadow still zeros output. High-warp analytic is unchanged."
+    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = Les vaisseaux en orbite conservent l'exposition solaire des panneaux de la dernière évaluation en temps réel (chargés à haute accélération ou non chargés). À faible accélération, l'ombre remet la sortie à zéro ; le mode analytique applique toujours la fraction d'ensoleillement orbital. Désactiver pour recalculer l'orientation hors chargement ou en mode analytique. // "In-space vessels keep sunlit solar-panel exposure from the last realtime evaluation (loaded high-warp or unloaded). Low-warp shadow still zeros output; analytic still applies the orbit sunlight fraction. Disable to recalculate panel facing while unloaded or in analytic warp."
     //
     #KERBALISM_Preferences_Science = Science // "Science"
     #KERBALISM_TransmitScienceImmediately = Transmettre Science Immédiatement // "Transmit Science Immediately"

--- a/GameData/Kerbalism/Localization/it-it.cfg
+++ b/GameData/Kerbalism/Localization/it-it.cfg
@@ -913,7 +913,7 @@ Localization
     //
     #KERBALISM_Preferences_General = Generale // "General"
     #KERBALISM_FreezeUnloadedSolarPanelExposure = Congela esposizione solare non caricata // "Freeze Unloaded Solar Exposure"
-    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = I vascelli in orbita non caricati a bassa accelerazione temporale mantengono l'esposizione solare dei pannelli dal passaggio da caricati a non caricati; in ombra l'output resta zero. La modalità analitica ad alta accelerazione non cambia. // "Unloaded in-space vessels at low timewarp keep sunlit solar-panel exposure from the loaded→unloaded transition; shadow still zeros output. High-warp analytic is unchanged."
+    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = I vascelli in orbita mantengono l'esposizione solare dei pannelli dall'ultima valutazione in tempo reale (caricati ad alta accelerazione o non caricati). In ombra a bassa accelerazione l'output resta zero; la modalità analitica applica ancora la frazione di luce orbitale. Disattivare per ricalcolare l'orientamento da non caricati o in modalità analitica. // "In-space vessels keep sunlit solar-panel exposure from the last realtime evaluation (loaded high-warp or unloaded). Low-warp shadow still zeros output; analytic still applies the orbit sunlight fraction. Disable to recalculate panel facing while unloaded or in analytic warp."
     //
     #KERBALISM_Preferences_Science = Scienza // "Science"
     #KERBALISM_TransmitScienceImmediately = Trasmetti scienza immediatamente // "Transmit Science Immediately"

--- a/GameData/Kerbalism/Localization/ko-kr.cfg
+++ b/GameData/Kerbalism/Localization/ko-kr.cfg
@@ -913,7 +913,7 @@ Localization
     //
     #KERBALISM_Preferences_General = 일반
     #KERBALISM_FreezeUnloadedSolarPanelExposure = 언로드 태양광 패널 노출 고정
-    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = 언로드된 궤도 선박은 낮은 시간 가속에서 로드에서 언로드로 전환할 때의 태양광 패널 노출을 유지합니다. 그림자에서는 출력이 0이 됩니다. 고속 시간 가속 해석 모드는 영향을 받지 않습니다.
+    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = 궤도 선박은 마지막 실시간 평가의 태양광 패널 노출을 유지합니다(고속 워프에서 로드되었거나 언로드된 경우). 낮은 시간 가속에서 그림자는 출력을 0으로 만들고, 해석 모드는 궤도 일조 비율을 계속 적용합니다. 끄면 언로드 또는 해석 모드에서 패널 방향을 다시 계산합니다.
     //
     #KERBALISM_Preferences_Science = 과학
     #KERBALISM_TransmitScienceImmediately = 즉시 과학 전송

--- a/GameData/Kerbalism/Localization/pt-br.cfg
+++ b/GameData/Kerbalism/Localization/pt-br.cfg
@@ -913,7 +913,7 @@ Localization
     //
     #KERBALISM_Preferences_General = Geral
     #KERBALISM_FreezeUnloadedSolarPanelExposure = Congelar exposição solar descarregada
-    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = Naves em órbita descarregadas em baixa aceleração temporal mantêm a exposição solar dos painéis do momento da transição carregado→descarregado; na sombra a saída continua zero. O modo analítico em alta aceleração não muda.
+    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = Naves em órbita mantêm a exposição solar dos painéis da última avaliação em tempo real (carregadas em alta aceleração ou descarregadas). Na sombra em baixa aceleração a saída continua zero; o modo analítico ainda aplica a fração de luz orbital. Desative para recalcular a orientação descarregada ou no modo analítico.
     //
     #KERBALISM_Preferences_Science = Ciência
     #KERBALISM_TransmitScienceImmediately = Transmitir Ciência Imediatamente

--- a/GameData/Kerbalism/Localization/ru.cfg
+++ b/GameData/Kerbalism/Localization/ru.cfg
@@ -909,7 +909,7 @@ Localization
     //
     #KERBALISM_Preferences_General = Общее // "General"
     #KERBALISM_FreezeUnloadedSolarPanelExposure = Заморозить освещённость выгруженных солнечных панелей // "Freeze Unloaded Solar Exposure"
-    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = У выгруженных космических кораблей при низкой перемотке времени освещённость панелей сохраняется с момента перехода в выгруженное состояние; в тени выходная мощность обнуляется. Аналитический режим при высокой перемотке не изменяется. // "Unloaded in-space vessels at low timewarp keep sunlit solar-panel exposure from the loaded→unloaded transition; shadow still zeros output. High-warp analytic is unchanged."
+    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = У космических кораблей освещённость панелей сохраняется с последней оценки в реальном времени (загруженные на высокой перемотке или выгруженные). В тени при низкой перемотке мощность обнуляется; аналитический режим по-прежнему учитывает долю солнечного времени на орбите. Отключите, чтобы пересчитывать ориентацию в выгруженном или аналитическом режиме. // "In-space vessels keep sunlit solar-panel exposure from the last realtime evaluation (loaded high-warp or unloaded). Low-warp shadow still zeros output; analytic still applies the orbit sunlight fraction. Disable to recalculate panel facing while unloaded or in analytic warp."
     //
     #KERBALISM_Preferences_Science = Наука // "Science"
     #KERBALISM_TransmitScienceImmediately = Передавать науку немедленно // "Transmit Science Immediately"

--- a/GameData/Kerbalism/Localization/zh-cn.cfg
+++ b/GameData/Kerbalism/Localization/zh-cn.cfg
@@ -913,7 +913,7 @@ Localization
     //
     #KERBALISM_Preferences_General = 通用 // "General"
     #KERBALISM_FreezeUnloadedSolarPanelExposure = 冻结未加载的太阳能板曝光 // "Freeze Unloaded Solar Exposure"
-    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = 未加载且低倍时间加速/无加速时，在轨飞船保持切走前的日照太阳能板曝光；阴影中仍归零。高倍时间加速解析模式不受影响。 // "Unloaded in-space vessels at low timewarp keep sunlit solar-panel exposure from the loaded→unloaded transition; shadow still zeros output. High-warp analytic is unchanged."
+    #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = 在轨飞船保持最近一次实时评估的日照太阳能板曝光（加载高倍速解析或未加载，朝向冻结）。低倍速阴影中仍归零；解析模式仍乘轨道日照比例。关闭则在未加载或解析时重算板朝向。 // "In-space vessels keep sunlit solar-panel exposure from the last realtime evaluation (loaded high-warp or unloaded). Low-warp shadow still zeros output; analytic still applies the orbit sunlight fraction. Disable to recalculate panel facing while unloaded or in analytic warp."
     //
     #KERBALISM_Preferences_Science = 科学 // "Science"
     #KERBALISM_TransmitScienceImmediately = 即时传输科学数据 // "Transmit Science Immediately"

--- a/src/Kerbalism/LocalizationCache.cs
+++ b/src/Kerbalism/LocalizationCache.cs
@@ -1203,7 +1203,7 @@ namespace KERBALISM
 		//
 		public static string Preferences_General = GetLoc("Preferences_General"); // "General"
 		public static string FreezeUnloadedSolarPanelExposure = GetLoc("FreezeUnloadedSolarPanelExposure"); // "Freeze Unloaded Solar Exposure"
-		public static string FreezeUnloadedSolarPanelExposure_desc = GetLoc("FreezeUnloadedSolarPanelExposure_desc"); // "Unloaded in-space vessels at low timewarp keep sunlit solar-panel exposure from the loaded→unloaded transition; shadow still zeros output. High-warp analytic is unchanged."
+		public static string FreezeUnloadedSolarPanelExposure_desc = GetLoc("FreezeUnloadedSolarPanelExposure_desc"); // "In-space vessels keep sunlit solar-panel exposure from the last realtime evaluation (loaded high-warp or unloaded). Low-warp shadow still zeros output; analytic still applies the orbit sunlight fraction. Disable to recalculate panel facing while unloaded or in analytic warp."
 
 		//
 		public static string Preferences_Science = GetLoc("Preferences_Science"); // "Science"

--- a/src/Kerbalism/Modules/SolarPanelFixer.cs
+++ b/src/Kerbalism/Modules/SolarPanelFixer.cs
@@ -586,8 +586,13 @@ namespace KERBALISM
 			if (vd.EnvIsAnalytic)
 			{
 				analyticSunlight = true;
-				powerFactor = CalculateMultiStarPowerAnalytic(vessel, vd.EnvSunsInfo, trackedSunInfo, SolarPanel.Type, SolarPanel.IsTracking, out theoreticalMaxPower, hasOrientation, panelPivotWorld, panelNormalWorld);
-				vd.SaveSolarPanelBackgroundExposure(powerFactor, theoreticalMaxPower, nominalRate, true);
+				if (TryGetFrozenPowerFactor(vessel, hasFrozenExposure, frozenExposure, vd, SolarPanel.Type, out powerFactor, out theoreticalMaxPower, out double telemetryActual))
+					vd.SaveSolarPanelBackgroundExposure(telemetryActual, theoreticalMaxPower, nominalRate, true);
+				else
+				{
+					powerFactor = CalculateMultiStarPowerAnalytic(vessel, vd.EnvSunsInfo, trackedSunInfo, SolarPanel.Type, SolarPanel.IsTracking, out theoreticalMaxPower, hasOrientation, panelPivotWorld, panelNormalWorld);
+					vd.SaveSolarPanelBackgroundExposure(powerFactor, theoreticalMaxPower, nominalRate, true);
+				}
 			}
 			else
 			{
@@ -822,12 +827,21 @@ namespace KERBALISM
 
 			bool hasOrientation = TryGetProtoPanelOrientation(v, p, m, isTracking, out Vector3d panelPivotWorld, out Vector3d panelNormalWorld);
 
-			// Optional freeze: reuse unload-time sunlit exposure at low warp; high-warp stays analytic.
+			// Optional freeze: reuse last realtime sunlit exposure (cosine). Analytic still
+			// scales EC by eclipse-inclusive SolarFlux, matching 3.32 unloaded/analytic behavior.
 			double theoreticalMaxPower;
 			double powerFactor;
-			if (!TryGetFrozenUnloadedPowerFactor(v, m, vd, prefab.SolarPanel.Type, out powerFactor, out theoreticalMaxPower))
+			double telemetryActual;
+			if (TryGetFrozenPowerFactor(v, Lib.Proto.GetBool(m, "hasFrozenExposure"), Lib.Proto.GetDouble(m, "frozenExposure"), vd, prefab.SolarPanel.Type, out powerFactor, out theoreticalMaxPower, out telemetryActual))
+			{
+				efficiencyFactor = powerFactor;
+			}
+			else
+			{
 				powerFactor = CalculateMultiStarPowerAnalytic(v, vd.EnvSunsInfo, trackedSunInfo, prefab.SolarPanel.Type, isTracking, out theoreticalMaxPower, hasOrientation, panelPivotWorld, panelNormalWorld);
-			efficiencyFactor = powerFactor;
+				efficiencyFactor = powerFactor;
+				telemetryActual = powerFactor;
+			}
 
 			// get wear factor (output degradation with time)
 			if (m.moduleValues.HasNode("timeEfficCurve"))
@@ -837,7 +851,7 @@ namespace KERBALISM
 				efficiencyFactor *= Lib.Clamp(teCurve.Evaluate((float)((Planetarium.GetUniversalTime() - launchUT) / 3600.0)), 0.0, 1.0);
 			}
 
-			vd.SaveSolarPanelBackgroundExposure(powerFactor, theoreticalMaxPower, nominalRate, vd.EnvIsAnalytic);
+			vd.SaveSolarPanelBackgroundExposure(telemetryActual, theoreticalMaxPower, nominalRate, vd.EnvIsAnalytic);
 
 			// calculate output
 			double output = nominalRate * efficiencyFactor;
@@ -1189,9 +1203,9 @@ namespace KERBALISM
 		}
 
 		/// <summary>
-		/// Cache the current loaded realtime sunlit exposure ratio so unloaded low-warp
-		/// simulation can optionally freeze it at the loaded→unloaded transition.
-		/// Does not change loaded power or telemetry.
+		/// Cache the current loaded realtime sunlit exposure ratio so unloaded vessels
+		/// and loaded analytic evaluation can optionally freeze it.
+		/// Does not change loaded realtime power.
 		/// </summary>
 		void TryCacheSunlitExposure(List<VesselData.SunInfo> suns, double powerFactor, double theoreticalMaxPower)
 		{
@@ -1203,34 +1217,33 @@ namespace KERBALISM
 		}
 
 		/// <summary>
-		/// When enabled, unloaded in-space vessels at low timewarp reuse the unload-time
-		/// sunlit exposure ratio. Shadow zeros output; high-warp analytic returns false.
+		/// When enabled, in-space vessels reuse the last realtime sunlit exposure ratio
+		/// while unloaded or in analytic warp. Discrete shadow still zeros output; analytic
+		/// keeps the orbit sunlight fraction because available flux already includes it.
+		/// Monitor exposure reports the frozen ratio (0 in discrete shadow), not the
+		/// eclipse-scaled power.
 		/// </summary>
-		static bool TryGetFrozenUnloadedPowerFactor(Vessel v, ProtoPartModuleSnapshot m, VesselData vd, ModuleDeployableSolarPanel.PanelType panelType, out double powerFactor, out double theoreticalMaxPower)
+		static bool TryGetFrozenPowerFactor(Vessel v, bool hasFrozen, double frozen, VesselData vd, ModuleDeployableSolarPanel.PanelType panelType, out double powerFactor, out double theoreticalMaxPower, out double telemetryActual)
 		{
 			powerFactor = 0.0;
 			theoreticalMaxPower = 0.0;
+			telemetryActual = 0.0;
 
 			PreferencesGeneral prefs = PreferencesGeneral.Instance;
 			if (prefs == null
 				|| !prefs.freezeUnloadedSolarPanelExposure
-				|| vd.EnvIsAnalytic
 				|| Lib.Landed(v)
-				|| !Lib.Proto.GetBool(m, "hasFrozenExposure"))
+				|| !hasFrozen)
 				return false;
 
-			double frozen = Lib.Proto.GetDouble(m, "frozenExposure");
 			if (frozen < 0.0 || double.IsNaN(frozen) || double.IsInfinity(frozen))
 				return false;
 
 			theoreticalMaxPower = CalculateTheoreticalMaxPower(vd.EnvSunsInfo, panelType);
-			if (GetSolarFluxWeight(vd.EnvSunsInfo) <= 1e-9)
-			{
-				powerFactor = 0.0;
-				return true;
-			}
-
-			powerFactor = Lib.Clamp(frozen, 0.0, 1.0) * theoreticalMaxPower;
+			double frozenClamped = Lib.Clamp(frozen, 0.0, 1.0);
+			double availableMaxPower = CalculateAvailableMaxPower(vd.EnvSunsInfo, panelType);
+			powerFactor = frozenClamped * availableMaxPower;
+			telemetryActual = availableMaxPower <= 0.0 ? 0.0 : frozenClamped * theoreticalMaxPower;
 			return true;
 		}
 
@@ -1257,19 +1270,35 @@ namespace KERBALISM
 		/// </summary>
 		static double CalculateTheoreticalMaxPower(List<VesselData.SunInfo> suns, ModuleDeployableSolarPanel.PanelType panelType)
 		{
+			return CalculateMaxPower(suns, panelType, includeBodyShadow: false);
+		}
+
+		/// <summary>
+		/// Like <see cref="CalculateTheoreticalMaxPower"/>, but uses each star's current
+		/// <see cref="VesselData.SunInfo.SolarFlux"/> (discrete 0/1 shadow, or analytic sunlight fraction).
+		/// </summary>
+		static double CalculateAvailableMaxPower(List<VesselData.SunInfo> suns, ModuleDeployableSolarPanel.PanelType panelType)
+		{
+			return CalculateMaxPower(suns, panelType, includeBodyShadow: true);
+		}
+
+		static double CalculateMaxPower(List<VesselData.SunInfo> suns, ModuleDeployableSolarPanel.PanelType panelType, bool includeBodyShadow)
+		{
 			if (suns == null || Sim.SolarFluxAtHome <= double.Epsilon)
 				return 0.0;
 
 			double maxCosine = GetTheoreticalMaxCosineFactor(panelType);
-			double theoreticalMaxPower = 0.0;
+			double maxPower = 0.0;
 			foreach (VesselData.SunInfo sun in suns)
 			{
-				double unshadowedFlux = sun.SunData.SolarFlux(sun.Distance) * sun.AtmoFactor;
-				if (unshadowedFlux <= 0.0 || double.IsNaN(unshadowedFlux) || double.IsInfinity(unshadowedFlux))
+				double flux = includeBodyShadow
+					? sun.SolarFlux
+					: sun.SunData.SolarFlux(sun.Distance) * sun.AtmoFactor;
+				if (flux <= 0.0 || double.IsNaN(flux) || double.IsInfinity(flux))
 					continue;
-				theoreticalMaxPower += (unshadowedFlux / Sim.SolarFluxAtHome) * maxCosine;
+				maxPower += (flux / Sim.SolarFluxAtHome) * maxCosine;
 			}
-			return theoreticalMaxPower;
+			return maxPower;
 		}
 
 		/// <summary>

--- a/src/Kerbalism/System/Preferences.cs
+++ b/src/Kerbalism/System/Preferences.cs
@@ -443,7 +443,7 @@ namespace KERBALISM
 
 	public class PreferencesGeneral : GameParameters.CustomParameterNode
 	{
-		[GameParameters.CustomParameterUI("#KERBALISM_FreezeUnloadedSolarPanelExposure", toolTip = "#KERBALISM_FreezeUnloadedSolarPanelExposure_desc")]//Freeze Unloaded Solar Exposure--Unloaded in-space vessels at low timewarp keep sunlit solar-panel exposure from the loaded→unloaded transition; shadow still zeros output. High-warp analytic is unchanged.
+		[GameParameters.CustomParameterUI("#KERBALISM_FreezeUnloadedSolarPanelExposure", toolTip = "#KERBALISM_FreezeUnloadedSolarPanelExposure_desc")]//Freeze Unloaded Solar Exposure--In-space vessels keep sunlit solar-panel exposure from the last realtime evaluation (loaded high-warp or unloaded). Low-warp shadow still zeros output; analytic still applies the orbit sunlight fraction. Disable to recalculate panel facing while unloaded or in analytic warp.
 		public bool freezeUnloadedSolarPanelExposure = true;
 
 		public override GameParameters.GameMode GameMode { get { return GameParameters.GameMode.ANY; } }


### PR DESCRIPTION
Enabling freeze now also applies while unloaded or loaded in analytic warp, like 3.32: facing stays frozen, power still uses eclipse flux, the monitor shows the frozen ratio. Disable the option to recalculate facing.