### PR TITLE
Fix BDB Skylab compatibility; rebalance lab experiment multipliers (all labs)

### DIFF
--- a/GameData/KerbalismConfig/Support/Bluedog.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog.cfg
@@ -391,6 +391,17 @@
     @amount *= #$/DaysOfWater$
     maxAmount = #$amount$
   }
+  
+}
+
+@PART[bluedog_*]:HAS[#DaysOfWater[>0],#CrewCapacity[>0]]:NEEDS[Bluedog_DB,ProfileDefault]:FOR[zzzKerbalismDefault]
+{
+  // Water is dense, and the masses of these parts are already tuned. Subtract the mass of the water we add from the dry mass of the part.
+  massReduction = #$/RESOURCE[Water]/amount$
+  @massReduction *= #$@RESOURCE_DEFINITION[Water]/density$
+
+  @mass -= #$massReduction$
+  -massReduction = delete
 }
 
 @PART[bluedog_*]:HAS[#DaysOfOxygen[>0],#CrewCapacity[>0]]:NEEDS[Bluedog_DB,ProfileDefault]:FOR[zzzKerbalismDefault]

--- a/GameData/KerbalismConfig/Support/Bluedog_Science.cfg
+++ b/GameData/KerbalismConfig/Support/Bluedog_Science.cfg
@@ -645,7 +645,6 @@
         ec_rate = #$@KERBALISM_EXPERIMENT_VALUES/BDB/bd_atm/ec_rate$
         allow_shrouded = False
         requires = Sunlight,CrewMin:2
-        crew_prepare = Engineer@1
         crew_operate = Scientist@2
         sample_amount = 16 // Pack extra film, just in case
     }

--- a/GameData/KerbalismConfig/System/ScienceRework/Patches-Experiments.cfg
+++ b/GameData/KerbalismConfig/System/ScienceRework/Patches-Experiments.cfg
@@ -397,14 +397,9 @@
 
 @PART[*]:HAS[@MODULE[Configure]:HAS[#configureId[LaboratoryExperiments]]]:NEEDS[FeatureScience]:FOR[zzzKerbalismDefault]
 {
-	// Following #775, this doesn't make any sense to me since lab experiments are only on labs, 
-	// why mass-patch their defined stats here ? Leaving as is because I'm lazy and I don't care.
-	@MODULE[Experiment],*
+	// Remove crew reset requirements for laboratory experiments
+	@MODULE[Experiment]:HAS[#experiment_ID[mobileMaterialsLab,mysteryGoo]]
 	{
-		@data_rate *= #$@KERBALISM_GROUP_SETTINGS/LAB_EXPERIMENTS/LabDataRateMultiplier$
-		@ec_rate *= #$@KERBALISM_GROUP_SETTINGS/LAB_EXPERIMENTS/LabECMultiplier$
-		// removed, see issue #775, don't override lab experiments crew reqs
-		// %crew_operate = Scientist  
 		!crew_reset = del
 	}
 

--- a/GameData/KerbalismConfig/System/ScienceRework/Patches-Experiments.cfg
+++ b/GameData/KerbalismConfig/System/ScienceRework/Patches-Experiments.cfg
@@ -398,7 +398,7 @@
 @PART[*]:HAS[@MODULE[Configure]:HAS[#configureId[LaboratoryExperiments]]]:NEEDS[FeatureScience]:FOR[zzzKerbalismDefault]
 {
 	// Remove crew reset requirements for laboratory experiments
-	@MODULE[Experiment]:HAS[#experiment_ID[mobileMaterialsLab,mysteryGoo]]
+	@MODULE[Experiment]:HAS[#experiment_id[mobileMaterialsLab,mysteryGoo]]
 	{
 		!crew_reset = del
 	}

--- a/GameData/KerbalismConfig/System/ScienceRework/Tweakables/StockGroups-Lab.cfg
+++ b/GameData/KerbalismConfig/System/ScienceRework/Tweakables/StockGroups-Lab.cfg
@@ -1,8 +1,8 @@
 // Lab exclusive experiments (with the exception of goo and matbay).
 // tried to cover most situations (landed, orbital, underwater, flying)
 // makes the labs have a purpose again.
-// I preffer for the labs to require scientists at varying levels present at all times to do the experiments.
-// high ec requirements are appropriate imo, adds a requirement to design stuff properly.
+// I prefer for the labs to require scientists at varying levels present at all times to do the experiments.
+// high ec requirements are appropriate imo, adds a requirement to design stuff properly. - UsernamesAreAlwaysTaken
 @KERBALISM_GROUP_SETTINGS:NEEDS[FeatureScience]
 {
 	LAB_EXPERIMENTS
@@ -15,16 +15,18 @@
 		ReconfigureRequirement = Scientist:5
 		ReconfigureEntryCost = 65000
 		LabDataRateMultiplier = 2					// Duration reduction for labs.
-		LabECMultiplier = 5							// EC Cost multiplier
+		LabECMultiplier = 2							// EC Cost multiplier
 		LabSampleReservoirMultiplier = 2			// for experiments that have sampling reservoirs.
 
 
 		CHILLED										//plant growth, 200-ish days (same as a greenhouse cycle. both orbital and landed, no biomes.
 		{
 			ECCost = 4.62
+			@ECCost *= #$../LabECMultiplier$
 			size = 22568
 			value = 24								// No biomes, thus fairly high value.
 			duration = 4320000						// 200 days
+			@duration /= #$../LabDataRateMultiplier$
 			SetupMass = 3.55
 			SetupCost = 12800
 			UnlockTech = advExploration
@@ -36,9 +38,11 @@
 		RELAX										//3 month geological research, landed, biomes, i'll allow kerbin.
 		{
 			ECCost = 10.92
+			@ECCost *= #$../LabECMultiplier$
 			size = 14928
 			value = 28								// lower value due to biomes
 			duration = 2052000						// 90-ish days
+			@duration /= #$../LabDataRateMultiplier$
 			SetupMass = 5.27
 			SetupCost = 16300
 			UnlockTech = fieldScience
@@ -50,9 +54,11 @@
 		JAMMED								//Low orbit only, no biomes, 18 months.
 		{
 			ECCost = 1.28
+			@ECCost *= #$../LabECMultiplier$
 			size = 9942
 			value = 30								// high-ish value due to being available once per orbital body.
 			duration = 5832000						// 9 months ingame. due to Shadow requirement, it'll take double. No cheesing because orbit.
+			@duration /= #$../LabDataRateMultiplier$
 			SetupMass = 2.74
 			SetupCost = 25720
 			UnlockTech = scienceTech
@@ -64,9 +70,11 @@
 		TRAPPED								//landed, 2 years, intended for ground bases. no biomes
 		{
 			ECCost = 2.67
+			@ECCost *= #$../LabECMultiplier$
 			size = 5838274							// <- lol.
 			value = 38								// it better be worth it.
 			duration = 19958400						// 2 years
+			@duration /= #$../LabDataRateMultiplier$
 			SetupMass = 6.74
 			SetupCost = 35180
 			UnlockTech = heavyLanding
@@ -78,9 +86,11 @@
 		SALINE										//4 months, underwater, biomes. I'll allow kerbin
 		{
 			ECCost = 6.32
+			@ECCost *= #$../LabECMultiplier$
 			size = 6490
 			value = 27								// starting value.
 			duration = 2592000						// 4 months
+			@duration /= #$../LabDataRateMultiplier$
 			SetupMass = 1.35
 			SetupCost = 7440
 			UnlockTech = fieldScience
@@ -91,9 +101,11 @@
 		BIRDIE								//Atmospheric experiment, flying high/low, Flying low biomes. have fun carrying a lab around. I'll also allow kerbin
 		{
 			ECCost = 1.42
+			@ECCost *= #$../LabECMultiplier$
 			size = 58
 			value = 14								// starting value.
 			duration = 1800							// 30 min, otherwise it's too grindy
+			@duration /= #$../LabDataRateMultiplier$
 			SetupMass = 0.38
 			SetupCost = 17830
 			UnlockTech = highAltitudeFlight


### PR DESCRIPTION
Fixed some issues mostly related to Skylab for BDB

- The crew reset requirement on the Apollo Telescope Mount was not working, removed it
- Reduce mass on parts that get extra supply. This mostly applies to Skylab which launched with a large water supply. 
- Skylab is large enough that both laboratory and crew experiments get added. The existing lab multiplier applied to all experiments on the part, including the crew experiments.
- I dug into the commit history and found that the values in StockGroups-Lab.cfg were intended to be the final [values.](https://github.com/Kerbalism/Kerbalism/commit/1f6316ee4f4e81f4aa9fb3cb3aee6f0f27ef87f9) Thus the lab multipliers are applied twice. To avoid breaking existing saves by doubling the experiment duration, I left the duration multipliers as is but reduced the EC multiplier from 5x to 2x to bring them down to more reasonable values. Mystery goo and materials study are short enough that they didn't need the duration reduction in the first place, but they kept their sample capacity and reset ability.

