### PR TITLE
Reuse per-tick crew, drive, and ResourceUpdate buffers

### DIFF
--- a/src/Kerbalism/Database/PartData.cs
+++ b/src/Kerbalism/Database/PartData.cs
@@ -9,7 +9,18 @@ namespace KERBALISM
 	{
 		public uint FlightId { get; private set; }
 
-		public Drive Drive { get; set; }
+		Drive drive;
+		public Drive Drive
+		{
+			get { return drive; }
+			set
+			{
+				if (drive == value)
+					return;
+				drive = value;
+				VesselData.BumpDriveCacheEpoch();
+			}
+		}
 
 		public PartData(Part part)
 		{

--- a/src/Kerbalism/Database/VesselData.cs
+++ b/src/Kerbalism/Database/VesselData.cs
@@ -43,6 +43,67 @@ namespace KERBALISM
 		/// <summary>name of last file being transmitted, or empty if nothing is being transmitted</summary>
 		public List<File> filesTransmitted;
 
+		/// <summary> Per-sim-tick crew snapshot. Do not mutate. </summary>
+		readonly List<ProtoCrewMember> crewSimTick = new List<ProtoCrewMember>();
+		uint crewSimTickId;
+
+		readonly List<Drive> drivesAll = new List<Drive>();
+		readonly List<Drive> drivesPublic = new List<Drive>();
+		uint drivesEpoch;
+		bool drivesDirty = true;
+
+		/// <summary> Bumped when any PartData.Drive is assigned so drive lists rebuild without allocating. </summary>
+		internal static uint DriveCacheEpoch;
+
+		readonly Dictionary<string, double> resourceUpdateAvailable = new Dictionary<string, double>();
+		readonly List<KeyValuePair<string, double>> resourceUpdateRequests = new List<KeyValuePair<string, double>>();
+
+		internal static void BumpDriveCacheEpoch()
+		{
+			unchecked { DriveCacheEpoch++; }
+		}
+
+		internal void InvalidateDriveCache()
+		{
+			drivesDirty = true;
+		}
+
+		/// <summary> Crew snapshot for <see cref="Kerbalism.SimTick"/>. Do not mutate. </summary>
+		internal List<ProtoCrewMember> CrewForSimTick(Vessel v)
+		{
+			if (crewSimTickId == Kerbalism.SimTick)
+				return crewSimTick;
+
+			crewSimTickId = Kerbalism.SimTick;
+			Lib.CopyVesselCrew(v, crewSimTick);
+			return crewSimTick;
+		}
+
+		/// <summary> Cached drive lists. Do not mutate the returned list. </summary>
+		internal List<Drive> GetDrives(bool includePrivate)
+		{
+			if (drivesDirty || drivesEpoch != DriveCacheEpoch)
+				RebuildDriveCache();
+			return includePrivate ? drivesAll : drivesPublic;
+		}
+
+		void RebuildDriveCache()
+		{
+			drivesAll.Clear();
+			drivesPublic.Clear();
+			foreach (PartData pd in parts.Values)
+			{
+				Drive d = pd.Drive;
+				if (d == null)
+					continue;
+				drivesAll.Add(d);
+				if (!d.is_private)
+					drivesPublic.Add(d);
+			}
+			drivesDirty = false;
+			drivesEpoch = DriveCacheEpoch;
+		}
+
 		#endregion
 
 		#region non-evaluated persisted fields
@@ -76,6 +137,7 @@ namespace KERBALISM
 					{
 						pd = new PartData(p);
 						parts.Add(flightID, pd);
+						InvalidateDriveCache();
 						Lib.LogDebug("VesselData : newly created part '{0}' added to vessel '{1}'", Lib.LogLevel.Message, p.partInfo.title, Vessel.vesselName);
 					}
 				}
@@ -663,17 +725,17 @@ namespace KERBALISM
 
 			List<ResourceInfo> allResources = resources.GetAllResources(Vessel); // there might be some performance to be gained by caching the list of all resource
 
-			Dictionary<string, double> availableResources = new Dictionary<string, double>();
+			resourceUpdateAvailable.Clear();
 			foreach (var ri in allResources)
-				availableResources[ri.ResourceName] = ri.Amount;
-			List<KeyValuePair<string, double>> resourceChangeRequests = new List<KeyValuePair<string, double>>();
+				resourceUpdateAvailable[ri.ResourceName] = ri.Amount;
+			resourceUpdateRequests.Clear();
 
 			foreach(var resourceUpdateDelegate in resourceUpdateDelegates)
 			{
-				resourceChangeRequests.Clear();
-				string title = resourceUpdateDelegate.invoke(availableResources, resourceChangeRequests);
+				resourceUpdateRequests.Clear();
+				string title = resourceUpdateDelegate.invoke(resourceUpdateAvailable, resourceUpdateRequests);
 				ResourceBroker broker = ResourceBroker.GetOrCreate(title);
-				foreach (var rc in resourceChangeRequests)
+				foreach (var rc in resourceUpdateRequests)
 				{
 					if (rc.Value > 0) resources.Produce(Vessel, rc.Key, rc.Value * elapsed_s, broker);
 					if (rc.Value < 0) resources.Consume(Vessel, rc.Key, -rc.Value * elapsed_s, broker);
@@ -693,6 +755,7 @@ namespace KERBALISM
 				return;
 
 			resourceUpdateDelegates = null;
+			InvalidateDriveCache();
 			ResetReliabilityStatus();
 			habitatInfo.Reset();
 			EvaluateStatus(0.0);
@@ -749,6 +812,7 @@ namespace KERBALISM
 				if (!toVD.parts.ContainsKey(fromPart.flightID))
 				{
 					toVD.parts.Add(fromPart.flightID, new PartData(fromPart));
+					toVD.InvalidateDriveCache();
                     OnPartCoupleComplete(fromPart, toPart);
                     Lib.LogDebug("VesselData : newly created part '{0}' added to vessel '{1}'", Lib.LogLevel.Message, fromPart.partInfo.title, toPart.vessel.vesselName);
 				}
@@ -762,6 +826,8 @@ namespace KERBALISM
 			}
 			// remove all partdata from the docking vessel
 			fromVD.parts.Clear();
+			fromVD.InvalidateDriveCache();
+			toVD.InvalidateDriveCache();
 
 			// reset a few things on the docked to vessel
 			toVD.supplies.Clear();

--- a/src/Kerbalism/Lib.cs
+++ b/src/Kerbalism/Lib.cs
@@ -1776,9 +1776,61 @@ namespace KERBALISM
 
 
 		///<summary>return set of crew on a vessel. Works on loaded and unloaded vessels</summary>
+		/// <remarks>
+		/// During flight simulation the returned list is a per-tick snapshot on VesselData.
+		/// Do not mutate it. Outside of FixedUpdate (SimTick == 0) this falls back to stock GetVesselCrew.
+		/// </remarks>
 		public static List<ProtoCrewMember> CrewList(Vessel v)
 		{
+			if (v == null)
+				return emptyCrew;
+
+			if (Kerbalism.SimTick != 0 && v.TryGetVesselData(out VesselData vd))
+				return vd.CrewForSimTick(v);
+
 			return v.loaded ? v.GetVesselCrew() : v.protoVessel.GetVesselCrew();
+		}
+
+		static readonly List<ProtoCrewMember> emptyCrew = new List<ProtoCrewMember>();
+
+		/// <summary> Copy vessel crew into <paramref name="dest"/> without allocating a stock GetVesselCrew list. </summary>
+		internal static void CopyVesselCrew(Vessel v, List<ProtoCrewMember> dest)
+		{
+			dest.Clear();
+			if (v == null)
+				return;
+
+			if (v.loaded)
+			{
+				List<Part> parts = v.parts;
+				for (int i = 0; i < parts.Count; i++)
+				{
+					List<ProtoCrewMember> partCrew = parts[i].protoModuleCrew;
+					if (partCrew == null)
+						continue;
+					for (int j = 0; j < partCrew.Count; j++)
+						dest.Add(partCrew[j]);
+				}
+				return;
+			}
+
+			if (v.protoVessel == null)
+				return;
+
+			CopyProtoVesselCrew(v.protoVessel, dest);
+		}
+
+		static void CopyProtoVesselCrew(ProtoVessel pv, List<ProtoCrewMember> dest)
+		{
+			List<ProtoPartSnapshot> snaps = pv.protoPartSnapshots;
+			for (int i = 0; i < snaps.Count; i++)
+			{
+				List<ProtoCrewMember> partCrew = snaps[i].protoModuleCrew;
+				if (partCrew == null)
+					continue;
+				for (int j = 0; j < partCrew.Count; j++)
+					dest.Add(partCrew[j]);
+			}
 		}
 
 		///<summary>return crew count of a vessel. Works on loaded and unloaded vessels</summary>
@@ -1793,7 +1845,21 @@ namespace KERBALISM
 			if (pv == null)
 				return 0;
 
-			return pv.vesselType == VesselType.EVA ? 1 : pv.GetVesselCrew().Count();
+			if (pv.vesselType == VesselType.EVA)
+				return 1;
+
+			if (Kerbalism.SimTick != 0 && pv.TryGetVesselData(out VesselData vd) && vd.Vessel != null)
+				return vd.CrewForSimTick(vd.Vessel).Count;
+
+			int n = 0;
+			List<ProtoPartSnapshot> snaps = pv.protoPartSnapshots;
+			for (int i = 0; i < snaps.Count; i++)
+			{
+				List<ProtoCrewMember> partCrew = snaps[i].protoModuleCrew;
+				if (partCrew != null)
+					n += partCrew.Count;
+			}
+			return n;
 		}
 
 		///<summary>return crew capacity of a vessel</summary>

--- a/src/Kerbalism/Science/Drive.cs
+++ b/src/Kerbalism/Science/Drive.cs
@@ -113,24 +113,28 @@ namespace KERBALISM
 			if (size < double.Epsilon)
 				return 0;
 
-			// store what we can
+			// Prefer the warp/transmit buffer, then vessel drives. Do not mutate the cached drive list.
+			double remaining = size;
+			if (!TryStoreOnDrive(vessel.KerbalismData().TransmitBufferDrive, subjectData, ref remaining) || remaining <= double.Epsilon)
+				return remaining;
 
-			var drives = GetDrives(vessel, include_private);
-			drives.Insert(0, vessel.KerbalismData().TransmitBufferDrive);
-
-			foreach (var d in drives)
+			List<Drive> drives = GetDrives(vessel, include_private);
+			for (int i = 0; i < drives.Count; i++)
 			{
-				var available = d.FileCapacityAvailable();
-				var chunk = Math.Min(size, available);
-				if (!d.Record_file(subjectData, chunk, true))
-					break;
-				size -= chunk;
-
-				if (size < double.Epsilon)
-					break;
+				if (!TryStoreOnDrive(drives[i], subjectData, ref remaining) || remaining <= double.Epsilon)
+					return remaining;
 			}
 
-			return size;
+			return remaining;
+		}
+
+		static bool TryStoreOnDrive(Drive d, SubjectData subjectData, ref double size)
+		{
+			double chunk = Math.Min(size, d.FileCapacityAvailable());
+			if (!d.Record_file(subjectData, chunk, true))
+				return false;
+			size -= chunk;
+			return true;
 		}
 
 		// add science data, creating new file or incrementing existing one
@@ -527,16 +531,7 @@ namespace KERBALISM
 		public static List<Drive> GetDrives (VesselData vd, bool includePrivate = false)
 		{
 			Profiler.BeginSample("Drive.GetDrives");
-			List<Drive> drives = new List<Drive>();
-
-			foreach (PartData partData in vd.PartDatas)
-			{
-				if (partData.Drive != null && (includePrivate || !partData.Drive.is_private))
-				{
-					drives.Add(partData.Drive);
-				}
-			}
-
+			List<Drive> drives = vd.GetDrives(includePrivate);
 			Profiler.EndSample();
 			return drives;
 		}

--- a/src/Kerbalism/Science/Science.cs
+++ b/src/Kerbalism/Science/Science.cs
@@ -39,6 +39,9 @@ namespace KERBALISM
 
 		// utility things
 		static readonly List<XmitFile> xmitFiles = new List<XmitFile>();
+		static readonly List<XmitFile> xmitFilePool = new List<XmitFile>();
+		static readonly List<SubjectData> filesToRemove = new List<SubjectData>();
+		static readonly Comparison<XmitFile> compareSciencePerMB = CompareSciencePerMB;
 
 		private class XmitFile
 		{
@@ -48,7 +51,7 @@ namespace KERBALISM
 			public bool isInWarpCache;
 			public File realDriveFile; // reference to the "real" file for files in the warp cache
 
-			public XmitFile(File file, Drive drive, double sciencePerMB, bool isInWarpCache, File realDriveFile = null)
+			public void Reset(File file, Drive drive, double sciencePerMB, bool isInWarpCache, File realDriveFile = null)
 			{
 				this.file = file;
 				this.drive = drive;
@@ -56,6 +59,31 @@ namespace KERBALISM
 				this.isInWarpCache = isInWarpCache;
 				this.realDriveFile = realDriveFile;
 			}
+		}
+
+		static XmitFile RentXmitFile(File file, Drive drive, double sciencePerMB, bool isInWarpCache, File realDriveFile = null)
+		{
+			XmitFile xf;
+			int last = xmitFilePool.Count - 1;
+			if (last >= 0)
+			{
+				xf = xmitFilePool[last];
+				xmitFilePool.RemoveAt(last);
+			}
+			else
+			{
+				xf = new XmitFile();
+			}
+			xf.Reset(file, drive, sciencePerMB, isInWarpCache, realDriveFile);
+			xmitFiles.Add(xf);
+			return xf;
+		}
+
+		static void ReleaseXmitFiles()
+		{
+			for (int i = 0; i < xmitFiles.Count; i++)
+				xmitFilePool.Add(xmitFiles[i]);
+			xmitFiles.Clear();
 		}
 
 		// pseudo-ctor
@@ -181,8 +209,8 @@ namespace KERBALISM
 			Profiler.BeginSample("GetFilesToTransmit");
 			Drive warpCache = vd.TransmitBufferDrive;
 
-			xmitFiles.Clear();
-			List<SubjectData> filesToRemove = new List<SubjectData>();
+			ReleaseXmitFiles();
+			filesToRemove.Clear();
 
 			foreach (Drive drive in Drive.GetDrives(vd, true))
 			{
@@ -203,7 +231,7 @@ namespace KERBALISM
 					// get files tagged for transmit
 					if (drive.GetFileSend(f.subjectData.Id))
 					{
-						xmitFiles.Add(new XmitFile(f, drive, f.subjectData.SciencePerMB, false));
+						RentXmitFile(f, drive, f.subjectData.SciencePerMB, false);
 					}
 				}
 
@@ -217,7 +245,7 @@ namespace KERBALISM
 			// sort files by science value per MB ascending order so high value files are transmitted first
 			// because XmitFile list is processed from end to start
 			Profiler.BeginSample("GetFilesToTransmit-Sort");
-			xmitFiles.Sort((x, y) => x.sciencePerMB.CompareTo(y.sciencePerMB));
+			xmitFiles.Sort(compareSciencePerMB);
 			Profiler.EndSample();
 
 			// add all warpcache files to the beginning of the XmitFile list
@@ -229,14 +257,27 @@ namespace KERBALISM
 
 				// find the file on a "real" drive that correspond to this warpcache file
 				// this allow to use the real file for displaying transmit info and saving state (filemanager, monitor, vesseldata...)
-				int driveFileIndex = xmitFiles.FindIndex(df => df.file.subjectData == f.subjectData);
-				if (driveFileIndex >= 0)
-					xmitFiles.Add(new XmitFile(f, warpCache, f.subjectData.SciencePerMB, true, xmitFiles[driveFileIndex].file));
+				File realDriveFile = null;
+				for (int i = 0; i < xmitFiles.Count; i++)
+				{
+					if (xmitFiles[i].file.subjectData == f.subjectData)
+					{
+						realDriveFile = xmitFiles[i].file;
+						break;
+					}
+				}
+				if (realDriveFile != null)
+					RentXmitFile(f, warpCache, f.subjectData.SciencePerMB, true, realDriveFile);
 				else
-					xmitFiles.Add(new XmitFile(f, warpCache, f.subjectData.SciencePerMB, true)); // should not be happening, but better safe than sorry
+					RentXmitFile(f, warpCache, f.subjectData.SciencePerMB, true); // should not be happening, but better safe than sorry
 
 			}
 			Profiler.EndSample();
+		}
+
+		static int CompareSciencePerMB(XmitFile x, XmitFile y)
+		{
+			return x.sciencePerMB.CompareTo(y.sciencePerMB);
 		}
 
 		// return module acting as container of an experiment

--- a/src/Kerbalism/System/Kerbalism.cs
+++ b/src/Kerbalism/System/Kerbalism.cs
@@ -69,6 +69,12 @@ namespace KERBALISM
 		// note: stored here to avoid converting it to double every time
 		public static double elapsed_s;
 
+		/// <summary>
+		/// Incremented once per Kerbalism FixedUpdate. Used as a generation for per-tick scratch caches
+		/// (crew lists, etc.). 0 means FixedUpdate has not run yet (editor / main menu).
+		/// </summary>
+		internal static uint SimTick { get; private set; }
+
 		// number of steps from last warp blending
 		private static uint warp_blending;
 
@@ -264,6 +270,10 @@ namespace KERBALISM
 			// do nothing if paused
 			if (Lib.IsPaused())
 				return;
+
+			unchecked { SimTick++; }
+			if (SimTick == 0)
+				SimTick = 1;
 
 			// convert elapsed time to double only once
 			double fixedDeltaTime = TimeWarp.fixedDeltaTime;


### PR DESCRIPTION
## Change Description
- Snapshot vessel crew once per Kerbalism FixedUpdate instead of calling stock `GetVesselCrew` from every Supply, Rule, and specialist Process.
- Cache `Drive.GetDrives` on VesselData (invalidate on vessel/part/drive changes) and stop mutating the returned list in `StoreFile`.
- Reuse loaded `ResourceUpdate` Dictionary/List the same way Background already does, and pool Science `XmitFile` / `filesToRemove`.
