### PR TITLE
Allow more background vessels to be processed per tick

### DIFF
--- a/GameData/Kerbalism/Localization/de.cfg
+++ b/GameData/Kerbalism/Localization/de.cfg
@@ -914,6 +914,10 @@ Localization
     #KERBALISM_Preferences_General = Allgemein // "General"
     #KERBALISM_FreezeUnloadedSolarPanelExposure = Unbeladene Solarpaneel-Exposition einfrieren // "Freeze Unloaded Solar Exposure"
     #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = Schiffe im Orbit behalten die Sonnenexposition der Solarpaneele aus der letzten Echtzeit-Auswertung (beladen bei hoher Zeitbeschleunigung oder entladen). Im Schatten bei niedriger Zeitbeschleunigung bleibt die Ausgabe null; der analytische Modus wendet weiterhin den Bahn-Sonnenanteil an. Deaktivieren, um die Ausrichtung im entladenen oder analytischen Zustand neu zu berechnen. // "In-space vessels keep sunlit solar-panel exposure from the last realtime evaluation (loaded high-warp or unloaded). Low-warp shadow still zeros output; analytic still applies the orbit sunlight fraction. Disable to recalculate panel facing while unloaded or in analytic warp."
+    #KERBALISM_BackgroundVesselsFlight = BG vessel evaluations / frame (flight)
+    #KERBALISM_BackgroundVesselsFlight_desc = Maximum number of unloaded vessels that get background processing on each physics tick while in flight.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nRaising it improves accuracy during fast warp, at the cost of framerate.
+    #KERBALISM_BackgroundVesselsOtherScenes = BG vessel evaluations / frame (others)
+    #KERBALISM_BackgroundVesselsOtherScenes_desc = Maximum number of unloaded vessels that get background processing on each physics tick in the Space Center, Tracking Station and Editor.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nThese scenes have far more CPU headroom than flight, so a higher value is safe.
     //
     #KERBALISM_Preferences_Science = Wissenschaft // "Science"
     #KERBALISM_TransmitScienceImmediately = Wissenschaft sofort übertragen // "Transmit Science Immediately"

--- a/GameData/Kerbalism/Localization/en-us.cfg
+++ b/GameData/Kerbalism/Localization/en-us.cfg
@@ -914,6 +914,10 @@ Localization
     #KERBALISM_Preferences_General = General
     #KERBALISM_FreezeUnloadedSolarPanelExposure = Freeze Unloaded Solar Exposure
     #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = In-space vessels keep sunlit solar-panel exposure from the last realtime evaluation (loaded high-warp or unloaded). Low-warp shadow still zeros output; analytic still applies the orbit sunlight fraction. Disable to recalculate panel facing while unloaded or in analytic warp.
+    #KERBALISM_BackgroundVesselsFlight = BG vessel evaluations / frame (flight)
+    #KERBALISM_BackgroundVesselsFlight_desc = Maximum number of unloaded vessels that get background processing on each physics tick while in flight.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nRaising it improves accuracy during fast warp, at the cost of framerate.
+    #KERBALISM_BackgroundVesselsOtherScenes = BG vessel evaluations / frame (others)
+    #KERBALISM_BackgroundVesselsOtherScenes_desc = Maximum number of unloaded vessels that get background processing on each physics tick in the Space Center, Tracking Station and Editor.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nThese scenes have far more CPU headroom than flight, so a higher value is safe.
     //
     #KERBALISM_Preferences_Science = Science
     #KERBALISM_TransmitScienceImmediately = Transmit Science Immediately

--- a/GameData/Kerbalism/Localization/es-es.cfg
+++ b/GameData/Kerbalism/Localization/es-es.cfg
@@ -914,6 +914,10 @@ Localization
     #KERBALISM_Preferences_General = General
     #KERBALISM_FreezeUnloadedSolarPanelExposure = Congelar exposición solar sin cargar
     #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = Las naves en órbita mantienen la exposición solar de los paneles de la última evaluación en tiempo real (cargadas a alta aceleración o sin cargar). En sombra a baja aceleración la salida sigue siendo cero; el modo analítico sigue aplicando la fracción de luz orbital. Desactivar para recalcular la orientación sin cargar o en modo analítico.
+    #KERBALISM_BackgroundVesselsFlight = BG vessel evaluations / frame (flight)
+    #KERBALISM_BackgroundVesselsFlight_desc = Maximum number of unloaded vessels that get background processing on each physics tick while in flight.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nRaising it improves accuracy during fast warp, at the cost of framerate.
+    #KERBALISM_BackgroundVesselsOtherScenes = BG vessel evaluations / frame (others)
+    #KERBALISM_BackgroundVesselsOtherScenes_desc = Maximum number of unloaded vessels that get background processing on each physics tick in the Space Center, Tracking Station and Editor.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nThese scenes have far more CPU headroom than flight, so a higher value is safe.
     //
     #KERBALISM_Preferences_Science = Ciencia
     #KERBALISM_TransmitScienceImmediately = Transmitir ciencia inmediatamente

--- a/GameData/Kerbalism/Localization/fr-fr.cfg
+++ b/GameData/Kerbalism/Localization/fr-fr.cfg
@@ -914,6 +914,10 @@ Localization
     #KERBALISM_Preferences_General = Général // "General"
     #KERBALISM_FreezeUnloadedSolarPanelExposure = Geler l'exposition solaire hors chargement // "Freeze Unloaded Solar Exposure"
     #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = Les vaisseaux en orbite conservent l'exposition solaire des panneaux de la dernière évaluation en temps réel (chargés à haute accélération ou non chargés). À faible accélération, l'ombre remet la sortie à zéro ; le mode analytique applique toujours la fraction d'ensoleillement orbital. Désactiver pour recalculer l'orientation hors chargement ou en mode analytique. // "In-space vessels keep sunlit solar-panel exposure from the last realtime evaluation (loaded high-warp or unloaded). Low-warp shadow still zeros output; analytic still applies the orbit sunlight fraction. Disable to recalculate panel facing while unloaded or in analytic warp."
+    #KERBALISM_BackgroundVesselsFlight = BG vessel evaluations / frame (flight)
+    #KERBALISM_BackgroundVesselsFlight_desc = Maximum number of unloaded vessels that get background processing on each physics tick while in flight.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nRaising it improves accuracy during fast warp, at the cost of framerate.
+    #KERBALISM_BackgroundVesselsOtherScenes = BG vessel evaluations / frame (others)
+    #KERBALISM_BackgroundVesselsOtherScenes_desc = Maximum number of unloaded vessels that get background processing on each physics tick in the Space Center, Tracking Station and Editor.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nThese scenes have far more CPU headroom than flight, so a higher value is safe.
     //
     #KERBALISM_Preferences_Science = Science // "Science"
     #KERBALISM_TransmitScienceImmediately = Transmettre Science Immédiatement // "Transmit Science Immediately"

--- a/GameData/Kerbalism/Localization/it-it.cfg
+++ b/GameData/Kerbalism/Localization/it-it.cfg
@@ -914,6 +914,10 @@ Localization
     #KERBALISM_Preferences_General = Generale // "General"
     #KERBALISM_FreezeUnloadedSolarPanelExposure = Congela esposizione solare non caricata // "Freeze Unloaded Solar Exposure"
     #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = I vascelli in orbita mantengono l'esposizione solare dei pannelli dall'ultima valutazione in tempo reale (caricati ad alta accelerazione o non caricati). In ombra a bassa accelerazione l'output resta zero; la modalità analitica applica ancora la frazione di luce orbitale. Disattivare per ricalcolare l'orientamento da non caricati o in modalità analitica. // "In-space vessels keep sunlit solar-panel exposure from the last realtime evaluation (loaded high-warp or unloaded). Low-warp shadow still zeros output; analytic still applies the orbit sunlight fraction. Disable to recalculate panel facing while unloaded or in analytic warp."
+    #KERBALISM_BackgroundVesselsFlight = BG vessel evaluations / frame (flight)
+    #KERBALISM_BackgroundVesselsFlight_desc = Maximum number of unloaded vessels that get background processing on each physics tick while in flight.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nRaising it improves accuracy during fast warp, at the cost of framerate.
+    #KERBALISM_BackgroundVesselsOtherScenes = BG vessel evaluations / frame (others)
+    #KERBALISM_BackgroundVesselsOtherScenes_desc = Maximum number of unloaded vessels that get background processing on each physics tick in the Space Center, Tracking Station and Editor.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nThese scenes have far more CPU headroom than flight, so a higher value is safe.
     //
     #KERBALISM_Preferences_Science = Scienza // "Science"
     #KERBALISM_TransmitScienceImmediately = Trasmetti scienza immediatamente // "Transmit Science Immediately"

--- a/GameData/Kerbalism/Localization/ko-kr.cfg
+++ b/GameData/Kerbalism/Localization/ko-kr.cfg
@@ -914,6 +914,10 @@ Localization
     #KERBALISM_Preferences_General = 일반
     #KERBALISM_FreezeUnloadedSolarPanelExposure = 언로드 태양광 패널 노출 고정
     #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = 궤도 선박은 마지막 실시간 평가의 태양광 패널 노출을 유지합니다(고속 워프에서 로드되었거나 언로드된 경우). 낮은 시간 가속에서 그림자는 출력을 0으로 만들고, 해석 모드는 궤도 일조 비율을 계속 적용합니다. 끄면 언로드 또는 해석 모드에서 패널 방향을 다시 계산합니다.
+    #KERBALISM_BackgroundVesselsFlight = BG vessel evaluations / frame (flight)
+    #KERBALISM_BackgroundVesselsFlight_desc = Maximum number of unloaded vessels that get background processing on each physics tick while in flight.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nRaising it improves accuracy during fast warp, at the cost of framerate.
+    #KERBALISM_BackgroundVesselsOtherScenes = BG vessel evaluations / frame (others)
+    #KERBALISM_BackgroundVesselsOtherScenes_desc = Maximum number of unloaded vessels that get background processing on each physics tick in the Space Center, Tracking Station and Editor.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nThese scenes have far more CPU headroom than flight, so a higher value is safe.
     //
     #KERBALISM_Preferences_Science = 과학
     #KERBALISM_TransmitScienceImmediately = 즉시 과학 전송

--- a/GameData/Kerbalism/Localization/pt-br.cfg
+++ b/GameData/Kerbalism/Localization/pt-br.cfg
@@ -914,6 +914,10 @@ Localization
     #KERBALISM_Preferences_General = Geral
     #KERBALISM_FreezeUnloadedSolarPanelExposure = Congelar exposição solar descarregada
     #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = Naves em órbita mantêm a exposição solar dos painéis da última avaliação em tempo real (carregadas em alta aceleração ou descarregadas). Na sombra em baixa aceleração a saída continua zero; o modo analítico ainda aplica a fração de luz orbital. Desative para recalcular a orientação descarregada ou no modo analítico.
+    #KERBALISM_BackgroundVesselsFlight = BG vessel evaluations / frame (flight)
+    #KERBALISM_BackgroundVesselsFlight_desc = Maximum number of unloaded vessels that get background processing on each physics tick while in flight.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nRaising it improves accuracy during fast warp, at the cost of framerate.
+    #KERBALISM_BackgroundVesselsOtherScenes = BG vessel evaluations / frame (others)
+    #KERBALISM_BackgroundVesselsOtherScenes_desc = Maximum number of unloaded vessels that get background processing on each physics tick in the Space Center, Tracking Station and Editor.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nThese scenes have far more CPU headroom than flight, so a higher value is safe.
     //
     #KERBALISM_Preferences_Science = Ciência
     #KERBALISM_TransmitScienceImmediately = Transmitir Ciência Imediatamente

--- a/GameData/Kerbalism/Localization/ru.cfg
+++ b/GameData/Kerbalism/Localization/ru.cfg
@@ -910,6 +910,10 @@ Localization
     #KERBALISM_Preferences_General = Общее // "General"
     #KERBALISM_FreezeUnloadedSolarPanelExposure = Заморозить освещённость выгруженных солнечных панелей // "Freeze Unloaded Solar Exposure"
     #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = У космических кораблей освещённость панелей сохраняется с последней оценки в реальном времени (загруженные на высокой перемотке или выгруженные). В тени при низкой перемотке мощность обнуляется; аналитический режим по-прежнему учитывает долю солнечного времени на орбите. Отключите, чтобы пересчитывать ориентацию в выгруженном или аналитическом режиме. // "In-space vessels keep sunlit solar-panel exposure from the last realtime evaluation (loaded high-warp or unloaded). Low-warp shadow still zeros output; analytic still applies the orbit sunlight fraction. Disable to recalculate panel facing while unloaded or in analytic warp."
+    #KERBALISM_BackgroundVesselsFlight = BG vessel evaluations / frame (flight)
+    #KERBALISM_BackgroundVesselsFlight_desc = Maximum number of unloaded vessels that get background processing on each physics tick while in flight.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nRaising it improves accuracy during fast warp, at the cost of framerate.
+    #KERBALISM_BackgroundVesselsOtherScenes = BG vessel evaluations / frame (others)
+    #KERBALISM_BackgroundVesselsOtherScenes_desc = Maximum number of unloaded vessels that get background processing on each physics tick in the Space Center, Tracking Station and Editor.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nThese scenes have far more CPU headroom than flight, so a higher value is safe.
     //
     #KERBALISM_Preferences_Science = Наука // "Science"
     #KERBALISM_TransmitScienceImmediately = Передавать науку немедленно // "Transmit Science Immediately"

--- a/GameData/Kerbalism/Localization/zh-cn.cfg
+++ b/GameData/Kerbalism/Localization/zh-cn.cfg
@@ -914,6 +914,10 @@ Localization
     #KERBALISM_Preferences_General = 通用 // "General"
     #KERBALISM_FreezeUnloadedSolarPanelExposure = 冻结未加载的太阳能板曝光 // "Freeze Unloaded Solar Exposure"
     #KERBALISM_FreezeUnloadedSolarPanelExposure_desc = 在轨飞船保持最近一次实时评估的日照太阳能板曝光（加载高倍速解析或未加载，朝向冻结）。低倍速阴影中仍归零；解析模式仍乘轨道日照比例。关闭则在未加载或解析时重算板朝向。 // "In-space vessels keep sunlit solar-panel exposure from the last realtime evaluation (loaded high-warp or unloaded). Low-warp shadow still zeros output; analytic still applies the orbit sunlight fraction. Disable to recalculate panel facing while unloaded or in analytic warp."
+    #KERBALISM_BackgroundVesselsFlight = BG vessel evaluations / frame (flight)
+    #KERBALISM_BackgroundVesselsFlight_desc = Maximum number of unloaded vessels that get background processing on each physics tick while in flight.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nRaising it improves accuracy during fast warp, at the cost of framerate.
+    #KERBALISM_BackgroundVesselsOtherScenes = BG vessel evaluations / frame (others)
+    #KERBALISM_BackgroundVesselsOtherScenes_desc = Maximum number of unloaded vessels that get background processing on each physics tick in the Space Center, Tracking Station and Editor.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nThese scenes have far more CPU headroom than flight, so a higher value is safe.
     //
     #KERBALISM_Preferences_Science = 科学 // "Science"
     #KERBALISM_TransmitScienceImmediately = 即时传输科学数据 // "Transmit Science Immediately"

--- a/src/Kerbalism/LocalizationCache.cs
+++ b/src/Kerbalism/LocalizationCache.cs
@@ -1204,6 +1204,10 @@ namespace KERBALISM
 		public static string Preferences_General = GetLoc("Preferences_General"); // "General"
 		public static string FreezeUnloadedSolarPanelExposure = GetLoc("FreezeUnloadedSolarPanelExposure"); // "Freeze Unloaded Solar Exposure"
 		public static string FreezeUnloadedSolarPanelExposure_desc = GetLoc("FreezeUnloadedSolarPanelExposure_desc"); // "In-space vessels keep sunlit solar-panel exposure from the last realtime evaluation (loaded high-warp or unloaded). Low-warp shadow still zeros output; analytic still applies the orbit sunlight fraction. Disable to recalculate panel facing while unloaded or in analytic warp."
+		public static string BackgroundVesselsFlight = GetLoc("BackgroundVesselsFlight"); // "BG vessel evaluations / frame (flight)"
+		public static string BackgroundVesselsFlight_desc = GetLoc("BackgroundVesselsFlight_desc"); // "Maximum number of unloaded vessels that get background processing on each physics tick while in flight.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nRaising it improves accuracy during fast warp, at the cost of framerate."
+		public static string BackgroundVesselsOtherScenes = GetLoc("BackgroundVesselsOtherScenes"); // "BG vessel evaluations / frame (others)"
+		public static string BackgroundVesselsOtherScenes_desc = GetLoc("BackgroundVesselsOtherScenes_desc"); // "Maximum number of unloaded vessels that get background processing on each physics tick in the Space Center, Tracking Station and Editor.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nThese scenes have far more CPU headroom than flight, so a higher value is safe."
 
 		//
 		public static string Preferences_Science = GetLoc("Preferences_Science"); // "Science"

--- a/src/Kerbalism/System/Kerbalism.cs
+++ b/src/Kerbalism/System/Kerbalism.cs
@@ -60,6 +60,16 @@ namespace KERBALISM
 		sealed class Unloaded_data { public double time; }; //< reference wrapper
 		static Dictionary<Guid, Unloaded_data> unloaded = new Dictionary<Guid, Unloaded_data>();
 
+		// the unloaded vessels selected for background processing in the current step, sorted by
+		// accumulated time in descending order. Kept around and reused to avoid per-step allocations.
+		struct Vessel_bg_processing_item { public double time; public Vessel vessel; };
+		static readonly List<Vessel_bg_processing_item> bg_vessels = new List<Vessel_bg_processing_item>();
+
+		// Accumulated time under which stepping a vessel separately buys us little of value.
+		// Only the oldest vessel is processed below this, which keeps the per-tick cost at
+		// one vessel at low timewarp no matter how high the settings are set.
+		const double bg_batch_threshold = 120.0;
+
 		// used to update storm data on one body per step
 		static int storm_index;
 		class Storm_data { public double time; public CelestialBody body; };
@@ -277,12 +287,9 @@ namespace KERBALISM
 			// update elapsed time
 			elapsed_s = fixedDeltaTime;
 
-			// store info for oldest unloaded vessel
-			double last_time = 0.0;
-			Guid last_id = Guid.Empty;
-			Vessel last_v = null;
-			VesselData last_vd = null;
-			VesselResources last_resources = null;
+			// select the oldest unloaded vessels for background processing
+			int max_bg_vessels = GetNumBGVesselsPerTick;
+			bg_vessels.Clear();
 
 			// credit science at regular interval
 			ScienceDB.CreditScienceBuffers(elapsed_s);
@@ -386,78 +393,79 @@ namespace KERBALISM
 					// accumulate time
 					ud.time += elapsed_s;
 
-					// maintain oldest entry
-					if (ud.time > last_time)
-					{
-						last_time = ud.time;
-						last_v = v;
-						last_vd = vd;
-						last_resources = resources;
-					}
+					// maintain the oldest entries
+					QueueForBackgroundUpdate(ud.time, v, max_bg_vessels);
 				}
 			}
 
-			// at most one vessel gets background processing per physics tick :
-			// if there is a vessel that is not the currently loaded vessel, then
-			// we will update the vessel whose most recent background update is the oldest
-			if (last_v != null)
+			// a limited number of vessels gets background processing per physics tick :
+			// among the vessels that are not the currently loaded vessel, we update the ones
+			// whose most recent background update is the oldest
+			for (int i = 0; i < bg_vessels.Count; i++)
 			{
+				Vessel_bg_processing_item step = bg_vessels[i];
+
+				// the oldest vessel is always processed, the rest only once they have piled up enough
+				// unsimulated time to be worth a separate step. The list is sorted, so we can stop here.
+				if (i > 0 && step.time < bg_batch_threshold)
+					break;
+
+				VesselData vd = step.vessel.KerbalismData();
+				VesselResources resources = ResourceCache.Get(step.vessel);
+
 				//Profiler.BeginSample("Unloaded.VesselDataEval");
 				// update the vessel info (high timewarp speeds reevaluation)
-				last_vd.Evaluate(false, last_time);
+				vd.Evaluate(false, step.time);
 				//Profiler.EndSample();
 
 				// get most used resource
-				ResourceInfo last_ec = last_resources.GetResource(last_v, "ElectricCharge");
+				ResourceInfo step_ec = resources.GetResource(step.vessel, "ElectricCharge");
 
 				Profiler.BeginSample("Unloaded.Radiation");
 				// show belt warnings
-				Radiation.BeltWarnings(last_v, last_vd);
+				Radiation.BeltWarnings(step.vessel, vd);
 
 				// update storm data
-				Storm.Update(last_v, last_vd, last_time);
+				Storm.Update(step.vessel, vd, step.time);
 				Profiler.EndSample();
 
 				Profiler.BeginSample("Unloaded.Comms");
-				CommsMessages.Update(last_v, last_vd, last_time);
+				CommsMessages.Update(step.vessel, vd, step.time);
 				Profiler.EndSample();
 
 				Profiler.BeginSample("Unloaded.Background");
 				// simulate modules in background
-				Background.Update(last_v, last_vd, last_resources, last_time);
+				Background.Update(step.vessel, vd, resources, step.time);
 				Profiler.EndSample();
 
-				if (SystemHeatBackgroundThermal.Active)
-				{
-					Profiler.BeginSample("Unloaded.SystemHeat");
-					SystemHeatBackgroundThermal.TryRun(last_v, last_time);
-					Profiler.EndSample();
+				Profiler.BeginSample("Unloaded.SystemHeat");
+				SystemHeatBackgroundThermal.TryRun(step.vessel, step.time);
+				Profiler.EndSample();
 
-					Profiler.BeginSample("Unloaded.FissionReactor");
-					SystemHeatBackgroundThermal.PrepareFrozenFissionReactors(last_v, last_time);
-					Profiler.EndSample();
-				}
+				Profiler.BeginSample("Unloaded.FissionReactor");
+				SystemHeatBackgroundThermal.PrepareFrozenFissionReactors(step.vessel, step.time);
+				Profiler.EndSample();
 
 				Profiler.BeginSample("Unloaded.Profile");
 				// apply rules
-				Profile.Execute(last_v, last_vd, last_resources, last_time);
+				Profile.Execute(step.vessel, vd, resources, step.time);
 				Profiler.EndSample();
 
 				Profiler.BeginSample("Unloaded.Science");
 				// transmit science	data
-				Science.Update(last_v, last_vd, last_ec, last_time);
+				Science.Update(step.vessel, vd, step_ec, step.time);
 				Profiler.EndSample();
 
 				Profiler.BeginSample("Unloaded.Resource");
 				// apply deferred requests
-				last_resources.Sync(last_v, last_vd, last_time);
+				resources.Sync(step.vessel, vd, step.time);
 				Profiler.EndSample();
 
 				// call automation scripts
-				last_vd.computer.Automate(last_v, last_vd, last_resources);
+				vd.computer.Automate(step.vessel, vd, resources);
 
 				// remove from unloaded data container
-				unloaded.Remove(last_vd.VesselId);
+				unloaded.Remove(vd.VesselId);
 			}
 
 			// update storm data for one body per-step
@@ -471,6 +479,49 @@ namespace KERBALISM
 				storm_index = (storm_index + 1) % storm_bodies.Count;
 				Profiler.EndSample();
 			}
+		}
+
+		/// <summary> How many unloaded vessels may get background processing in a single physics tick </summary>
+		private static int GetNumBGVesselsPerTick
+		{
+			get
+			{
+				PreferencesGeneral prefs = PreferencesGeneral.Instance;
+				if (prefs == null)
+					return 1;
+
+				// flight has to share the tick with physics and expensive game logic, the other scenes don't
+				int count = HighLogic.LoadedSceneIsFlight ? prefs.backgroundVesselsFlight : prefs.backgroundVesselsOtherScenes;
+				return Math.Max(1, count);
+			}
+		}
+
+		/// <summary>
+		/// Keep the <paramref name="max_count"/> unloaded vessels with the longest accumulated time in
+		/// background_steps, sorted in descending order. Called for every unloaded vessel of the step.
+		/// </summary>
+		private static void QueueForBackgroundUpdate(double time, Vessel v, int max_count)
+		{
+			// find the insertion point among the already selected vessels
+			int index = bg_vessels.Count;
+			while (index > 0 && bg_vessels[index - 1].time < time)
+				--index;
+
+			// the selection is full and this vessel is more recent than all of its entries
+			if (index >= max_count)
+				return;
+
+			// an older vessel is already selected, so this one can't end up being the one we are
+			// required to process, and it hasn't accumulated enough time to be worth batching.
+			// Skipping it here avoids churning the selection at low timewarp.
+			if (index > 0 && time < bg_batch_threshold)
+				return;
+
+			// drop the most recently updated entry to make room
+			if (bg_vessels.Count >= max_count)
+				bg_vessels.RemoveAt(bg_vessels.Count - 1);
+
+			bg_vessels.Insert(index, new Vessel_bg_processing_item { time = time, vessel = v });
 		}
 
 		#endregion

--- a/src/Kerbalism/System/Preferences.cs
+++ b/src/Kerbalism/System/Preferences.cs
@@ -446,6 +446,12 @@ namespace KERBALISM
 		[GameParameters.CustomParameterUI("#KERBALISM_FreezeUnloadedSolarPanelExposure", toolTip = "#KERBALISM_FreezeUnloadedSolarPanelExposure_desc")]//Freeze Unloaded Solar Exposure--In-space vessels keep sunlit solar-panel exposure from the last realtime evaluation (loaded high-warp or unloaded). Low-warp shadow still zeros output; analytic still applies the orbit sunlight fraction. Disable to recalculate panel facing while unloaded or in analytic warp.
 		public bool freezeUnloadedSolarPanelExposure = true;
 
+		[GameParameters.CustomIntParameterUI("#KERBALISM_BackgroundVesselsFlight", minValue = 1, maxValue = 32, toolTip = "#KERBALISM_BackgroundVesselsFlight_desc")]//BG vessel evaluations / frame (flight)--Maximum number of unloaded vessels that get background processing on each physics tick while in flight.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nRaising it improves accuracy during fast warp, at the cost of framerate.
+		public int backgroundVesselsFlight = 2;
+
+		[GameParameters.CustomIntParameterUI("#KERBALISM_BackgroundVesselsOtherScenes", minValue = 1, maxValue = 64, toolTip = "#KERBALISM_BackgroundVesselsOtherScenes_desc")]//BG vessel evaluations / frame (others)--Maximum number of unloaded vessels that get background processing on each physics tick in the Space Center, Tracking Station and Editor.\nExtra vessels are only processed once they have piled up more than two minutes of unsimulated time, so this does nothing at low time warp.\nThese scenes have far more CPU headroom than flight, so a higher value is safe.
+		public int backgroundVesselsOtherScenes = 4;
+
 		public override GameParameters.GameMode GameMode { get { return GameParameters.GameMode.ANY; } }
 
 		public override bool HasPresets { get { return true; } }


### PR DESCRIPTION
At minimum there's still at least one background vessel processed per FixedUpdate. However if there are vessels where more than 2 minutes have passed since the last update, Kerbalism can take those on as well. Also comes with configurable limits for flight scene and other scenes.