### PR TITLE
Fix infinite loop in resource recipe execution

### DIFF
--- a/src/Kerbalism/Resource.cs
+++ b/src/Kerbalism/Resource.cs
@@ -1149,9 +1149,9 @@ namespace KERBALISM
 		}
 
 		/// <summary>
-		/// Execute the recipe and record deferred consumption/production for inputs/ouputs.
-		/// This need to be called multiple times until left &lt;= 0.0 for complete execution of the recipe.
-		/// return true if recipe execution is completed, false otherwise
+		/// Execute the recipe and record deferred consumption/production for inputs/outputs.
+		/// This needs to be called multiple times until left &lt;= 0.0 for complete execution of the recipe.
+		/// Returns true if the recipe was executed at least partially, false if no progress is possible.
 		/// </summary>
 		private bool ExecuteRecipeStep(Vessel v, VesselResources resources)
 		{
@@ -1213,6 +1213,12 @@ namespace KERBALISM
 			{
 				worst_io = Lib.Clamp(executionLimiter(worst_io), 0.0, worst_io);
 			}
+
+			// A positive value can still be too small to change left at its current magnitude.
+			// Treat that as no progress, otherwise ExecuteRecipes() will loop forever.
+			double next_left = left - worst_io;
+			if (worst_io > double.Epsilon && !(next_left < left))
+				return false;
 
 			// consume inputs
 			for (int i = 0; i < inputs.Count; ++i)
@@ -1278,7 +1284,7 @@ namespace KERBALISM
 			}
 
 			// update amount left to execute
-			left -= worst_io;
+			left = next_left;
 
 			if (worst_io > double.Epsilon)
 				onExecuted?.Invoke(worst_io);


### PR DESCRIPTION
## Problem

KSP can stop responding during resource processing. The freeze occurs at the same game time after each reload of an affected save.

## Cause

`ExecuteRecipes()` repeats while a recipe reports progress. `ExecuteRecipeStep()` reported progress when `worst_io > double.Epsilon`.

A value can pass this test but still be too small to change `left` because of floating-point rounding. For example:

```text
left = 1.0
worst_io = 1E-323
worst_io > double.Epsilon       => true
left - worst_io < left          => false
```

In this case, the method returns `true`, but `left` does not change. The outer loop does not stop.

## Change

Calculate `next_left` before changing resources or calling callbacks. If `worst_io` passes the existing limit but `next_left` is not less than `left`, return `false`.

This change stops the loop when the recipe cannot make numerical progress. It does not change normal recipe steps that reduce `left`.

The change also corrects the method comment for the return value.

## Tests

- The freeze was reproduced with KSP 1.12.5 and Kerbalism 3.41. The main thread was in `Kerbalism.FixedUpdate -> Profile.Execute -> Science.Update -> VesselResources.Sync -> ResourceRecipe.ExecuteRecipes -> ExecuteRecipeStep`.
- Before this source change, the same check was applied as a runtime patch to the affected save. The save advanced for more than one Kerbin year at accelerated simulation speed. KSP did not freeze, and the log had no new errors.

